### PR TITLE
add map for free voxels

### DIFF
--- a/se_core/include/se/octree.hpp
+++ b/se_core/include/se/octree.hpp
@@ -120,6 +120,7 @@ class Octree {
    * \param y y coordinate in interval [0, size]
    * \param z z coordinate in interval [0, size]
    */
+   VoxelBlock<T> *fetch(const uint64_t morton) const;
   VoxelBlock<T> *fetch(const int x, const int y, const int z) const;
 
   /*! \brief Fetch the octant (x,y,z) at level depth
@@ -454,6 +455,11 @@ const {
 
 }
 
+template<typename T>
+inline VoxelBlock<T> *Octree<T>::fetch(const uint64_t morton) const {
+ Eigen::Vector3i coord = unpack_morton(morton);
+ return fetch(coord.x(), coord.y(), coord.z());
+}
 template<typename T>
 inline VoxelBlock<T> *Octree<T>::fetch(const int x, const int y, const int z) const {
 

--- a/se_denseslam/include/se/DenseSLAMSystem.h
+++ b/se_denseslam/include/se/DenseSLAMSystem.h
@@ -227,7 +227,8 @@ class DenseSLAMSystem {
                    float mu,
                    unsigned int frame,
                    set3i *updated_blocks,
-                   set3i *frontier_blocks);
+                   set3i *frontier_blocks,
+                   set3i *free_blocks);
   /**
    * Raycast the 3D reconstruction after integration to update the values of
    * the TSDF. This is the fourth stage of the pipeline.

--- a/se_denseslam/src/DenseSLAMSystem.cpp
+++ b/se_denseslam/src/DenseSLAMSystem.cpp
@@ -403,7 +403,8 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f &k,
                                   float mu,
                                   unsigned int frame,
                                   set3i *updated_blocks,
-                                  set3i *frontier_blocks) {
+                                  set3i *frontier_blocks,
+                                  set3i *free_blocks) {
 
 //bool DenseSLAMSystem::integration(const Eigen::Vector4f &k,
 //                                  unsigned int integration_rate,
@@ -474,6 +475,7 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f &k,
                                   timestamp,
                                   voxelsize,
                                   updated_blocks,
+                                  free_blocks,
                                   false, 1);
 // Update all active nodes and voxels using the bfusion_update function
 


### PR DESCRIPTION
for free voxels, add the morton code of its voxel block to a std::set. this is used for path planning

- add node iterator function to retrieve free voxels
- update signature of integration and bfusion update to add the morton code

a PR for the ROS wrapper will be opened