### PR TITLE
Sphere Check Update

### DIFF
--- a/se_core/include/se/geometry/octree_collision.hpp
+++ b/se_core/include/se/geometry/octree_collision.hpp
@@ -36,14 +36,17 @@
 namespace se {
 namespace geometry {
 enum class collision_status {
-  occupied, unseen, empty
+  occupied,
+  unseen,
+  empty
 };
 static std::ostream &operator<<(std::ostream &os, const collision_status &dt) {
   return os << static_cast<int>(dt);
 }
 /*! \brief Implements a simple state machine to update the collision status.
+ * For path planning, treat unseen as occupied.
  * The importance order is given as follows in ascending order: 
- * Empty, Unseen, Occupied.
+ * Occupied, Unseen, Empty.
  * \param previous_status
  * \param new_status 
  */
@@ -201,9 +204,9 @@ collision_status isSphereCollisionFree(const Octree<FieldType> &map,
   se::VoxelBlock<FieldType> *block = nullptr;
   bool is_voxel_block;
   Eigen::Vector3i prev_pos(0, 0, 0);
-  for (int x = -radius; x <= radius; x++) {
+  for (int z = -radius; z <= radius; z++) {
     for (int y = -radius; y <= radius; y++) {
-      for (int z = -radius; z <= radius; z++) {
+      for (int x = -radius; x <= radius; x++) {
         Eigen::Vector3i point_offset_v(x, y, z);
         //check if point is inside the sphere radius
 //        std::cout << "sphere norm " << point_offset_v.norm() <<std::endl;

--- a/se_core/include/se/geometry/octree_collision.hpp
+++ b/se_core/include/se/geometry/octree_collision.hpp
@@ -30,17 +30,15 @@
 #define OCTREE_COLLISION_HPP
 #include "../node.hpp"
 #include "../octree.hpp"
+#include "../utils/eigen_utils.h"
 #include "aabb_collision.hpp"
 
 namespace se {
 namespace geometry {
 enum class collision_status {
-  empty,
-  occupied,
-  unseen
+  occupied, unseen, empty
 };
-static  std::ostream& operator<<(std::ostream& os, const collision_status & dt)
-{
+static std::ostream &operator<<(std::ostream &os, const collision_status &dt) {
   return os << static_cast<int>(dt);
 }
 /*! \brief Implements a simple state machine to update the collision status.
@@ -49,20 +47,18 @@ static  std::ostream& operator<<(std::ostream& os, const collision_status & dt)
  * \param previous_status
  * \param new_status 
  */
-inline collision_status update_status(const collision_status previous_status, 
-    const collision_status new_status) {
-  switch(previous_status) {
+inline collision_status update_status(const collision_status previous_status,
+                                      const collision_status new_status) {
+  switch (previous_status) {
     case collision_status::unseen:
-      if(new_status != collision_status::occupied)
+      if (new_status != collision_status::occupied)
         return previous_status;
-      else 
+      else
         return new_status;
       break;
-    case collision_status::occupied:
-      return previous_status;
+    case collision_status::occupied:return previous_status;
       break;
-    default:
-      return new_status;
+    default:return new_status;
       break;
   }
 }
@@ -74,32 +70,34 @@ inline collision_status update_status(const collision_status previous_status,
  * \param block voxel block of type FieldType
  * \param test function that takes a voxel and returns a collision_status value
  */
-template <typename FieldType, typename TestVoxelF>
-collision_status collides_with(const se::VoxelBlock<FieldType>* block, 
-    const Eigen::Vector3i bbox, const Eigen::Vector3i side, TestVoxelF test) {
+template<typename FieldType, typename TestVoxelF>
+collision_status collides_with(const se::VoxelBlock<FieldType> *block,
+                               const Eigen::Vector3i bbox,
+                               const Eigen::Vector3i side,
+                               TestVoxelF test) {
   collision_status status = collision_status::empty;
   const Eigen::Vector3i blockCoord = block->coordinates();
-  int x, y, z, blockSide; 
+  int x, y, z, blockSide;
   blockSide = (int) se::VoxelBlock<FieldType>::side;
   int xlast = blockCoord(0) + blockSide;
   int ylast = blockCoord(1) + blockSide;
   int zlast = blockCoord(2) + blockSide;
-  Eigen::Vector3i center = bbox + side/2;
+  Eigen::Vector3i center = bbox + side / 2;
 
-  for(z = blockCoord(2); z < zlast; ++z){
-    for (y = blockCoord(1); y < ylast; ++y){
-      for (x = blockCoord(0); x < xlast; ++x){
+  for (z = blockCoord(2); z < zlast; ++z) {
+    for (y = blockCoord(1); y < ylast; ++y) {
+      for (x = blockCoord(0); x < xlast; ++x) {
 
         typename se::VoxelBlock<FieldType>::value_type value;
         const Eigen::Vector3i vox{x, y, z};
-        if(!geometry::aabb_aabb_collision(bbox, side, 
-          vox, Eigen::Vector3i::Constant(1))) continue;
+        if (!geometry::aabb_aabb_collision(bbox, side, vox, Eigen::Vector3i::Constant(1))) continue;
         value = block->data(Eigen::Vector3i(x, y, z));
-        if((Eigen::Vector3i(x,y,z)- center).norm()> side.x()/2){
-          std::cout << "se/collision bbox collision larger than radius" <<std::endl;
-        }
         status = update_status(status, test(value));
-
+        std::cout << "[se/collision] vb " << vox.format(InLine) << " status " << status
+                  << std::endl;
+//        if((Eigen::Vector3i(x,y,z)- center).norm()> side.x()/2){
+//
+//        }
       }
     }
   }
@@ -116,22 +114,24 @@ collision_status collides_with(const se::VoxelBlock<FieldType>* block,
  * \param test function that takes a voxel and returns a collision_status value
  */
 
-template <typename FieldType, typename TestVoxelF>
-collision_status collides_with(const Octree<FieldType>& map, 
-    const Eigen::Vector3i bbox, const Eigen::Vector3i side, TestVoxelF test) {
+template<typename FieldType, typename TestVoxelF>
+collision_status collides_with(const Octree<FieldType> &map,
+                               const Eigen::Vector3i bbox,
+                               const Eigen::Vector3i side,
+                               TestVoxelF test) {
 
-  typedef struct stack_entry { 
-    se::Node<FieldType>* node_ptr;
+  typedef struct stack_entry {
+    se::Node<FieldType> *node_ptr;
     Eigen::Vector3i coordinates;
     int side;
     typename se::Node<FieldType>::value_type parent_val;
   } stack_entry;
 
-  stack_entry stack[Octree<FieldType>::max_depth*8 + 1];
+  stack_entry stack[Octree<FieldType>::max_depth * 8 + 1];
   size_t stack_idx = 0;
 
-  se::Node<FieldType>* node = map.root();
-  if(!node) return collision_status::unseen;
+  se::Node<FieldType> *node = map.root();
+  if (!node) return collision_status::unseen;
 
   stack_entry current;
   current.node_ptr = node;
@@ -140,44 +140,124 @@ collision_status collides_with(const Octree<FieldType>& map,
   stack[stack_idx++] = current;
   collision_status status = collision_status::empty;
 
-  while(stack_idx != 0){
+  while (stack_idx != 0) {
     node = current.node_ptr;
 
-    if(node->isLeaf()){
-      status = collides_with(static_cast<se::VoxelBlock<FieldType>*>(node), 
-          bbox, side, test);
-    } 
-
-    if(node->children_mask_ == 0) {
-       current = stack[--stack_idx]; 
-       continue;
+    if (node->isLeaf()) {
+      status = collides_with(static_cast<se::VoxelBlock<FieldType> *>(node), bbox, side, test);
+      std::cout << "[bbox] node leaf" << se::keyops::decode(node->code_).format(InLine) << " "
+                                                                                           "status "
+                << status << std::endl;
     }
 
-    for(int i = 0; i < 8; ++i){
-      se::Node<FieldType>* child = node->child(i);
+    if (node->children_mask_ == 0) {
+      current = stack[--stack_idx];
+      continue;
+    }
+
+    for (int i = 0; i < 8; ++i) {
+      se::Node<FieldType> *child = node->child(i);
       stack_entry child_descr;
       child_descr.node_ptr = NULL;
       child_descr.side = current.side / 2;
-      child_descr.coordinates = 
-        Eigen::Vector3i(current.coordinates(0) + child_descr.side*((i & 1) > 0),
-            current.coordinates(1) + child_descr.side*((i & 2) > 0),
-            current.coordinates(2) + child_descr.side*((i & 4) > 0));
+      child_descr.coordinates =
+          Eigen::Vector3i(current.coordinates(0) + child_descr.side * ((i & 1) > 0),
+                          current.coordinates(1) + child_descr.side * ((i & 2) > 0),
+                          current.coordinates(2) + child_descr.side * ((i & 4) > 0));
 
-      const bool overlaps = geometry::aabb_aabb_collision(bbox, side, 
-          child_descr.coordinates, Eigen::Vector3i::Constant(child_descr.side));
+      const bool overlaps = geometry::aabb_aabb_collision(bbox,
+                                                          side,
+                                                          child_descr.coordinates,
+                                                          Eigen::Vector3i::Constant(child_descr.side));
 
-      if(overlaps && child != NULL) {
+      if (overlaps && child != NULL) {
         child_descr.node_ptr = child;
         child_descr.parent_val = node->value_[0];
         stack[stack_idx++] = child_descr;
-      } else if(overlaps && child == NULL) {
+      } else if (overlaps && child == NULL) {
         status = update_status(status, test(node->value_[0]));
+        std::cout << "[bbox] node " << se::keyops::decode(node->code_).format(InLine) << " status "
+                  << status << std::endl;
       }
     }
-    current = stack[--stack_idx]; 
+    current = stack[--stack_idx];
   }
   return status;
 }
+
+template<typename FieldType>
+collision_status isSphereCollisionFree(const Octree<FieldType> &map,
+                                       const Eigen::Vector3i center,
+                                       const int radius) {
+
+  se::Node<FieldType> *node = nullptr;
+  se::VoxelBlock<FieldType> *block = nullptr;
+  bool is_voxel_block;
+  Eigen::Vector3i prev_pos(0, 0, 0);
+  for (int x = -radius; x <= radius; x++) {
+    for (int y = -radius; y <= radius; y++) {
+      for (int z = -radius; z <= radius; z++) {
+        Eigen::Vector3i point_offset_v(x, y, z);
+        //check if point is inside the sphere radius
+        std::cout << "sphere norm " << point_offset_v.norm() <<std::endl;
+        if (point_offset_v.norm() <= radius) {
+          // check if voxelblock is allocated or only node
+          Eigen::Vector3i point_v = point_offset_v + center;
+          // first round
+          if (node == nullptr || block == nullptr) {
+            map.fetch_octant(point_v.x(), point_v.y(), point_v.z(), node, is_voxel_block);
+            prev_pos = point_v;
+            if (is_voxel_block) {
+              block = static_cast<se::VoxelBlock<FieldType> *> (node);
+            } else {
+              if (map.get(se::keyops::decode(node->code_)) < 10.f) {
+                std::cout << " [secollision] collision at node "
+                          << se::keyops::decode(node->code_).format(InLine) << std::endl;
+                return collision_status::occupied;
+              }
+            }
+          } else {
+            // if true keep old voxelblock pointer and fetch
+            // else get new voxel block
+            if ((point_v.x() / BLOCK_SIDE) == (prev_pos.x() / BLOCK_SIDE)
+                && ((point_v.y()) / BLOCK_SIDE) == (prev_pos.y() / BLOCK_SIDE)
+                && ((point_v.z()) / BLOCK_SIDE) == (prev_pos.z() / BLOCK_SIDE)) {
+              if (block->data(point_v) < 10.f) {
+                std::cout << " [secollision] collision at " << point_v.format(InLine) << " plog "
+                          << block->data(point_v) << std::endl;
+                return collision_status::occupied;
+              }
+            } else {
+              map.fetch_octant(point_v.x(), point_v.y(), point_v.z(), node, is_voxel_block);
+              if (is_voxel_block) {
+                block = static_cast<se::VoxelBlock<FieldType> *> (node);
+                if (block->data(point_v) < 10.f) {
+                  std::cout << " [secollision] collision at " << point_v.format(InLine) << " plog "
+                            << block->data(point_v) << std::endl;
+                  return collision_status::occupied;
+                }
+              } else {
+                block = nullptr;
+                if (map.get(se::keyops::decode(node->code_)) < 10.f) {
+                  std::cout << " [secollision] collision at node "
+                            << se::keyops::decode(node->code_).format(InLine) << std::endl;
+                  return collision_status::occupied;
+                }
+              }
+
+            }
+          }
+          prev_pos = point_v;
+        }
+
+      }
+    }
+  }
+//  std::cout << "[se/collision_checker] sphere radius " << planning_config_.cand_view_safety_radius
+//            << " [m] =  " << radius_v << " voxels around center " << pos_v.format(InLine) << std::endl;
+  return collision_status::empty;
+}
+
 }
 }
 #endif

--- a/se_core/include/se/geometry/octree_collision.hpp
+++ b/se_core/include/se/geometry/octree_collision.hpp
@@ -51,10 +51,7 @@ inline collision_status update_status(const collision_status previous_status,
                                       const collision_status new_status) {
   switch (previous_status) {
     case collision_status::unseen:
-      if (new_status != collision_status::occupied)
-        return previous_status;
-      else
-        return new_status;
+        return collision_status::occupied;
       break;
     case collision_status::occupied:return previous_status;
       break;
@@ -93,11 +90,9 @@ collision_status collides_with(const se::VoxelBlock<FieldType> *block,
         if (!geometry::aabb_aabb_collision(bbox, side, vox, Eigen::Vector3i::Constant(1))) continue;
         value = block->data(Eigen::Vector3i(x, y, z));
         status = update_status(status, test(value));
-        std::cout << "[se/collision] vb " << vox.format(InLine) << " status " << status
-                  << std::endl;
-//        if((Eigen::Vector3i(x,y,z)- center).norm()> side.x()/2){
-//
-//        }
+//        std::cout << "[se/collision] vb " << vox.format(InLine) << " status " << status
+//                  << std::endl;
+        if(status == collision_status::occupied){return status;}
       }
     }
   }
@@ -145,9 +140,9 @@ collision_status collides_with(const Octree<FieldType> &map,
 
     if (node->isLeaf()) {
       status = collides_with(static_cast<se::VoxelBlock<FieldType> *>(node), bbox, side, test);
-      std::cout << "[bbox] node leaf" << se::keyops::decode(node->code_).format(InLine) << " "
-                                                                                           "status "
-                << status << std::endl;
+//      std::cout << "[bbox] node leaf" << se::keyops::decode(node->code_).format(InLine)
+//      << " status "<< status << std::endl;
+      if(status == collision_status::occupied){return status;}
     }
 
     if (node->children_mask_ == 0) {
@@ -176,8 +171,9 @@ collision_status collides_with(const Octree<FieldType> &map,
         stack[stack_idx++] = child_descr;
       } else if (overlaps && child == NULL) {
         status = update_status(status, test(node->value_[0]));
-        std::cout << "[bbox] node " << se::keyops::decode(node->code_).format(InLine) << " status "
-                  << status << std::endl;
+//        std::cout << "[bbox] node " << se::keyops::decode(node->code_).format(InLine) << " status "
+//                  << status << std::endl;
+        if(status == collision_status::occupied){return status;}
       }
     }
     current = stack[--stack_idx];
@@ -185,6 +181,17 @@ collision_status collides_with(const Octree<FieldType> &map,
   return status;
 }
 
+
+
+
+/**
+ * used only in unit test, same logic as in path planning folder
+ * @tparam FieldType
+ * @param map
+ * @param center
+ * @param radius
+ * @return
+ */
 template<typename FieldType>
 collision_status isSphereCollisionFree(const Octree<FieldType> &map,
                                        const Eigen::Vector3i center,
@@ -199,7 +206,7 @@ collision_status isSphereCollisionFree(const Octree<FieldType> &map,
       for (int z = -radius; z <= radius; z++) {
         Eigen::Vector3i point_offset_v(x, y, z);
         //check if point is inside the sphere radius
-        std::cout << "sphere norm " << point_offset_v.norm() <<std::endl;
+//        std::cout << "sphere norm " << point_offset_v.norm() <<std::endl;
         if (point_offset_v.norm() <= radius) {
           // check if voxelblock is allocated or only node
           Eigen::Vector3i point_v = point_offset_v + center;

--- a/se_core/include/se/geometry/octree_collision.hpp
+++ b/se_core/include/se/geometry/octree_collision.hpp
@@ -39,7 +39,10 @@ enum class collision_status {
   unseen,
   empty
 };
-
+static  std::ostream& operator<<(std::ostream& os, const collision_status & dt)
+{
+  return os << static_cast<int>(dt);
+}
 /*! \brief Implements a simple state machine to update the collision status.
  * The importance order is given as follows in ascending order: 
  * Empty, Unseen, Occupied.

--- a/se_core/include/se/geometry/octree_collision.hpp
+++ b/se_core/include/se/geometry/octree_collision.hpp
@@ -35,9 +35,9 @@
 namespace se {
 namespace geometry {
 enum class collision_status {
+  empty,
   occupied,
-  unseen,
-  empty
+  unseen
 };
 static  std::ostream& operator<<(std::ostream& os, const collision_status & dt)
 {
@@ -84,6 +84,8 @@ collision_status collides_with(const se::VoxelBlock<FieldType>* block,
   int xlast = blockCoord(0) + blockSide;
   int ylast = blockCoord(1) + blockSide;
   int zlast = blockCoord(2) + blockSide;
+  Eigen::Vector3i center = bbox + side/2;
+
   for(z = blockCoord(2); z < zlast; ++z){
     for (y = blockCoord(1); y < ylast; ++y){
       for (x = blockCoord(0); x < xlast; ++x){
@@ -93,7 +95,11 @@ collision_status collides_with(const se::VoxelBlock<FieldType>* block,
         if(!geometry::aabb_aabb_collision(bbox, side, 
           vox, Eigen::Vector3i::Constant(1))) continue;
         value = block->data(Eigen::Vector3i(x, y, z));
+        if((Eigen::Vector3i(x,y,z)- center).norm()> side.x()/2){
+          std::cout << "se/collision bbox collision larger than radius" <<std::endl;
+        }
         status = update_status(status, test(value));
+
       }
     }
   }

--- a/se_core/include/se/octree.hpp
+++ b/se_core/include/se/octree.hpp
@@ -434,7 +434,6 @@ const {
   Node<T> *n = root_;
   if (!n) {
     pointer = nullptr;
-    std::cout << " no root" <<std::endl;
     return ;
   }
 
@@ -444,7 +443,7 @@ const {
     Node<T> *tmp  = n->child((x & edge) > 0u, (y & edge) > 0u, (z & edge) > 0u);
     if (!tmp) {
       pointer = n;
-      std::cout << "pointer = n "<< std::endl;
+
       return ;
     }
     n= tmp;

--- a/se_core/test/geometry/octree_collision_unittest.cpp
+++ b/se_core/test/geometry/octree_collision_unittest.cpp
@@ -129,6 +129,7 @@ TEST_F(OctreeCollisionTest, Collision) {
 }
 
 TEST_F(OctreeCollisionTest, CollisionFreeLeaf) {
+  // GIVEN this octree
   // Allocated block: {56, 8, 248};
   const Eigen::Vector3i test_bbox = {61, 13, 253};
   const Eigen::Vector3i width = {3, 3, 3};
@@ -137,12 +138,11 @@ TEST_F(OctreeCollisionTest, CollisionFreeLeaf) {
   const Eigen::Vector3i center = {61, 13, 253};
   const int radius = 1;
 
-  /* Update leaves as occupied node */
+  /* Update bottom left corner as occupied */
   se::VoxelBlock<testT> *block = oct_.fetch(56, 12, 254);
   const Eigen::Vector3i blockCoord = block->coordinates();
   int x, y, z, blockSide;
   blockSide = (int) se::VoxelBlock<testT>::side;
-//  testing::internal::CaptureStdout();
   int xlast = blockCoord(0) + blockSide;
   int ylast = blockCoord(1) + blockSide;
   int zlast = blockCoord(2) + blockSide;
@@ -158,17 +158,18 @@ TEST_F(OctreeCollisionTest, CollisionFreeLeaf) {
       }
     }
   }
-
+ // WHEN checking for collision in the upper right corner
   const collision_status collides = collides_with(oct_, test_bbox, width, test_voxel);
   const collision_status collidesSphere = isSphereCollisionFree(oct_, center, radius);
-//  std::string output = testing::internal::GetCapturedStdout();
-//  EXPECT_TRUE(false) << output;
+
+// THEN the space should be collision free
   ASSERT_EQ(collides, collision_status::empty);
   ASSERT_EQ(collidesSphere, collision_status::empty);
 
 }
 
 TEST_F(OctreeCollisionTest, CollisionLeaf) {
+  // GIVEN this octree
   // Allocated block: {56, 8, 248};
   const Eigen::Vector3i test_bbox = {57, 9, 249};
   const Eigen::Vector3i width = {5, 5, 5};
@@ -176,7 +177,7 @@ TEST_F(OctreeCollisionTest, CollisionLeaf) {
   // sphere
   const Eigen::Vector3i center = {60, 11, 251};
   const int radius = 2;
-  /* Update leaves as occupied node */
+  /* Update the center of the voxel block as occupied */
   se::VoxelBlock<testT> *block = oct_.fetch(56, 12, 254);
   const Eigen::Vector3i blockCoord = block->coordinates();
   int x, y, z, blockSide;
@@ -197,15 +198,17 @@ TEST_F(OctreeCollisionTest, CollisionLeaf) {
       }
     }
   }
-
+ // WHEN checking for collision in the voxel block
   const collision_status collides = collides_with(oct_, test_bbox, width, test_voxel);
   const collision_status collidesSphere = isSphereCollisionFree(oct_, center, radius);
   std::string output = testing::internal::GetCapturedStdout();
 //  EXPECT_TRUE(false) << output;
+// THEN: the collision status should be occupied, although some voxels are free
   ASSERT_EQ(collides, collision_status::occupied);
   ASSERT_EQ(collidesSphere, collision_status::occupied);
 }
 TEST_F(OctreeCollisionTest, NoSphereYesBox) {
+  // GIVEN this octree
   // Allocated block: {56, 8, 248};
   // bottom left corner of the box
   const Eigen::Vector3i test_bbox = {57, 9, 249};
@@ -216,7 +219,7 @@ TEST_F(OctreeCollisionTest, NoSphereYesBox) {
   const int radius = 2;
 
 
-  /* Update leaves as occupied node */
+  /* Update a small bottom left corner as occupied */
   se::VoxelBlock<testT> *block = oct_.fetch(56, 12, 254);
   const Eigen::Vector3i blockCoord = block->coordinates();
   int x, y, z, blockSide;
@@ -238,11 +241,12 @@ TEST_F(OctreeCollisionTest, NoSphereYesBox) {
       }
     }
   }
-
+// THEN checking for collision
   const collision_status collides = collides_with(oct_, test_bbox, width, test_voxel);
   const collision_status collidesSphere = isSphereCollisionFree(oct_, center, radius);
   std::string output = testing::internal::GetCapturedStdout();
 //  EXPECT_TRUE(false) << output;
+
 // THEN : the corner of the bounding box is occupied, whereas the sphere doesn't collide with it
   ASSERT_EQ(collides, collision_status::occupied);
 
@@ -260,7 +264,7 @@ TEST_F(OctreeCollisionTest, AcrossBlocksOccupied1) {
   const int radius = 2;
 
 
-  /* Update leaves as occupied node */
+  /* Update a small bottom left corner as occupied */
   se::VoxelBlock<testT> *block = oct_.fetch(56, 12, 254);
   const Eigen::Vector3i blockCoord = block->coordinates();
   int x, y, z, blockSide;
@@ -302,7 +306,7 @@ TEST_F(OctreeCollisionTest, AcrossBlocksOccupied2) {
   const int radius = 2;
 
 
-  /* Update leaves as occupied node */
+  /* Update a small bottom left corner as occupied */
   se::VoxelBlock<testT> *block = oct_.fetch(56, 12, 254);
   const Eigen::Vector3i blockCoord = block->coordinates();
   int x, y, z, blockSide;
@@ -348,7 +352,7 @@ TEST_F(OctreeCollisionTest, AcrossBlocksFree) {
     }
   };
   se::functor::axis_aligned_map(oct_, set_to_ten);
-  /* Update leaves as occupied node */
+  /* Update a small bottom left corner as occupied */
   se::VoxelBlock<testT> *block = oct_.fetch(56, 12, 254);
   const Eigen::Vector3i blockCoord = block->coordinates();
   int x, y, z, blockSide;

--- a/se_shared/include/se/path_planning/candidate_view.hpp
+++ b/se_shared/include/se/path_planning/candidate_view.hpp
@@ -36,10 +36,9 @@ namespace se {
 
 namespace exploration {
 
-
-static se::geometry::collision_status test_voxel2(const Volume<FieldType>::value_type & val) {
-  if(val.st == voxel_state::kUnknown) return se::geometry::collision_status::unseen;
-  if(val.st == voxel_state::kFree) return se::geometry::collision_status::empty;
+static se::geometry::collision_status test_voxel2(const Volume<FieldType>::value_type &val) {
+  if (val.st == voxel_state::kUnknown) return se::geometry::collision_status::unseen;
+  if (val.st == voxel_state::kFree) return se::geometry::collision_status::empty;
   return se::geometry::collision_status::occupied;
 };
 /**
@@ -65,12 +64,12 @@ class CandidateView {
 
   void printFaceVoxels(const Eigen::Vector3i &voxel);
 
-  std::pair<double,float> getInformationGain(const Volume<T> &volume,
-                            const Eigen::Vector3f &direction,
-                            const float tnear,
-                            const float tfar,
-                            const float step,
-                            const Eigen::Vector3f &origin);
+  std::pair<double, float> getInformationGain(const Volume<T> &volume,
+                                              const Eigen::Vector3f &direction,
+                                              const float tnear,
+                                              const float tfar,
+                                              const float step,
+                                              const Eigen::Vector3f &origin);
 
   VectorPairPoseDouble getCandidateGain(const float step);
 
@@ -91,7 +90,6 @@ class CandidateView {
   Planning_Configuration planning_config_;
   Configuration config_;
   float occ_thresh_ = 0.f;
-
 
 };
 
@@ -229,14 +227,19 @@ Eigen::Vector3i CandidateView<T>::getOffsetCandidate(const Eigen::Vector3i &cand
             << offset_cand_v.y() << " " << offset_cand_v.z() << " voxel state "
             << volume_._map_index->get(offset_cand_v).st;*/
 
-  int free_sphere = collision_check.isSphereCollisionFree(offset_cand_v);
 
-  if (is_valid && free_sphere == 1) {
+  if (is_valid) {
+    int free_sphere = collision_check.isSphereCollisionFree(offset_cand_v);
+    if (free_sphere == 1) {
       return offset_cand_v;
-  } else {
-    // not a valid view or sphere is not collision free
-    return Eigen::Vector3i(0, 0, 0);
+    }else{
+      return Eigen::Vector3i(0, 0, 0);
   }
+}
+else {
+// not a valid view or sphere is not collision free
+return Eigen::Vector3i(0, 0, 0);
+}
 
 }
 
@@ -302,19 +305,19 @@ void CandidateView<T>::getCandidateViews(const map3i &frontier_blocks_map) {
  */
 template<typename T>
 std::pair<double, float> CandidateView<T>::getInformationGain(const Volume<T> &volume,
-                                            const Eigen::Vector3f &direction,
-                                            const float tnear,
-                                            const float tfar,
-                                            const float step,
-                                            const Eigen::Vector3f &origin) {
+                                                              const Eigen::Vector3f &direction,
+                                                              const float tnear,
+                                                              const float tfar,
+                                                              const float step,
+                                                              const Eigen::Vector3f &origin) {
   auto select_occupancy = [](typename Volume<T>::value_type val) { return val.x; };
   // march from camera away
   double ig_entropy = 0.0f;
   float tanh_range = 4.f;
-  const float tanh_ratio = tanh_range / tfar ;
+  const float tanh_ratio = tanh_range / tfar;
   float t = tnear; // closer bound to camera
-  bool hit_unknown= false;
-  float t_hit  = 0.f;
+  bool hit_unknown = false;
+  float t_hit = 0.f;
   if (tnear < tfar) {
     float stepsize = step;
     // occupancy prob in log2
@@ -328,7 +331,7 @@ std::pair<double, float> CandidateView<T>::getInformationGain(const Volume<T> &v
         typename Volume<T>::value_type data = volume.get(pos);
         prob_log = volume.interp(origin + direction * t, select_occupancy);
         weight = getIGWeight_tanh(tanh_range, tanh_ratio, t, prob_log, t_hit, hit_unknown);
-        ig_entropy +=  weight * getEntropy(prob_log);
+        ig_entropy += weight * getEntropy(prob_log);
 /*        if (prob_log == 0.f) {
           std::cout << "[se/candview] raycast dist " << t
                     << " prob " << se::math::getProbFromLog(prob_log) << " weight " << weight
@@ -341,7 +344,7 @@ std::pair<double, float> CandidateView<T>::getInformationGain(const Volume<T> &v
       }
     }
   }
-  return std::make_pair(ig_entropy,t);
+  return std::make_pair(ig_entropy, t);
 }
 
 template<typename T>
@@ -353,14 +356,14 @@ const float CandidateView<T>::getIGWeight_tanh(const float tanh_range,
                                                bool &hit_unknown) const {
   float weight;
   if (prob_log == 0.f) {
-          if (!hit_unknown){
-            t_hit = t;
-            hit_unknown = true;
-          }
-          weight = tanh(tanh_range - (t-t_hit) * tanh_ratio);
-        } else {
-          weight = 1.f;
-        }
+    if (!hit_unknown) {
+      t_hit = t;
+      hit_unknown = true;
+    }
+    weight = tanh(tanh_range - (t - t_hit) * tanh_ratio);
+  } else {
+    weight = 1.f;
+  }
   return weight;
 }
 
@@ -423,7 +426,7 @@ VectorPairPoseDouble CandidateView<T>::getCandidateGain(const float step) {
       gain_matrix(row, col) = theta;
       depth_matrix(row, col) = theta;
       for (phi = static_cast<int>(90 - fov_vert / 2); phi < 90 + fov_vert / 2; phi += dphi) {
-        col ++;
+        col++;
         // calculate ray cast direction
         phi_rad = static_cast<float>(M_PI * phi / 180.0f);
         vec[0] = cand_view_m[0] + r_max * cos(theta_rad) * sin(phi_rad);
@@ -436,16 +439,16 @@ VectorPairPoseDouble CandidateView<T>::getCandidateGain(const float step) {
         // lower bound dist from camera
         const float t_min = ray.tcmin(); /* Get distance to the first intersected block */
         //get IG along ray
-        std::pair<double,float> gain_tmp =
-            t_min > 0.f ? getInformationGain(volume_, dir, t_min, r_max, step, cand_view_m) :
-            std::make_pair(0.,0.f);
+        std::pair<double, float> gain_tmp =
+            t_min > 0.f ? getInformationGain(volume_, dir, t_min, r_max, step, cand_view_m)
+                        : std::make_pair(0., 0.f);
         gain_matrix(row, col) = gain_tmp.first;
         depth_matrix(row, col) = gain_tmp.second;
         gain += gain_tmp.first;
       }
 
-      gain_matrix(row,col+1) = gain;
-      row ++;
+      gain_matrix(row, col + 1) = gain;
+      row++;
       // add gain to map
       gain_per_yaw[theta] = gain;
 
@@ -475,15 +478,15 @@ VectorPairPoseDouble CandidateView<T>::getCandidateGain(const float step) {
       }
     }
 
-/*    std::cout << "[se/candview] gain_matrix \n" << gain_matrix.transpose() << std::endl;
+    std::cout << "[se/candview] gain_matrix \n" << gain_matrix.transpose() << std::endl;
     std::cout << "[se/candview] depth_matrix \n" << depth_matrix.transpose() << std::endl;
     std::cout << "[se/candview] for cand " << cand_view.format(InLine) << " best theta angle is "
-              << best_yaw << ", best ig is " << best_yaw_gain << std::endl;*/
+              << best_yaw << ", best ig is " << best_yaw_gain << std::endl;
 
     float yaw_rad = M_PI * best_yaw / 180.f;
     pose3D best_pose;
     best_pose.p = cand_view.cast<float>();
-    best_pose.q = toQuaternion(yaw_rad, 0.0 , 0.0); // [rad] as input
+    best_pose.q = toQuaternion(yaw_rad, 0.0, 0.0); // [rad] as input
     cand_pose_w_gain.push_back(std::make_pair(best_pose, best_yaw_gain));
   }
   return cand_pose_w_gain;

--- a/se_shared/include/se/path_planning/candidate_view.hpp
+++ b/se_shared/include/se/path_planning/candidate_view.hpp
@@ -229,9 +229,8 @@ Eigen::Vector3i CandidateView<T>::getOffsetCandidate(const Eigen::Vector3i &cand
             << offset_cand_v.y() << " " << offset_cand_v.z() << " voxel state "
             << volume_._map_index->get(offset_cand_v).st;*/
   int free_sphere = collision_check.isSphereCollisionFree(offset_cand_v);
-
   if (is_valid) {
-    if (free_sphere==1.f) {
+    if (free_sphere==1) {
       return offset_cand_v;
     } else {
       // is valid but the sphere is not collision free

--- a/se_shared/include/se/path_planning/candidate_view.hpp
+++ b/se_shared/include/se/path_planning/candidate_view.hpp
@@ -228,16 +228,13 @@ Eigen::Vector3i CandidateView<T>::getOffsetCandidate(const Eigen::Vector3i &cand
             << " offset by " << offset_v << " results in " << offset_cand_v.x() << " "
             << offset_cand_v.y() << " " << offset_cand_v.z() << " voxel state "
             << volume_._map_index->get(offset_cand_v).st;*/
+
   int free_sphere = collision_check.isSphereCollisionFree(offset_cand_v);
-  if (is_valid) {
-    if (free_sphere==1) {
+
+  if (is_valid && free_sphere == 1) {
       return offset_cand_v;
-    } else {
-      // is valid but the sphere is not collision free
-      return Eigen::Vector3i(0, 0, 0);
-    }
   } else {
-    // not a valid view
+    // not a valid view or sphere is not collision free
     return Eigen::Vector3i(0, 0, 0);
   }
 
@@ -263,7 +260,6 @@ void CandidateView<T>::getCandidateViews(const map3i &frontier_blocks_map) {
   //check if block and voxel map size are equal
   if (frontier_voxels_map.size() != frontier_blocks_map.size()) {
   }
-
   // random candidate view generator
   std::default_random_engine generator;
   std::uniform_int_distribution<int> distribution_block(0, frontier_blocks_map.size() - 1);
@@ -553,11 +549,10 @@ void getExplorationPath(const Volume<T> &volume,
   VectorPairPoseDouble pose_gain = candidate_view.getCandidateGain(step);
 
   std::pair<pose3D, double> best_cand_pose_with_gain = candidate_view.getBestCandidate(pose_gain);
-  std::cout << "[se/candview] best candidate is " << best_cand_pose_with_gain.first.p.format(InLine)
-            << " yaw " << toEulerAngles(best_cand_pose_with_gain.first.q).yaw * 180.f / M_PI
-            << " with gain " << best_cand_pose_with_gain.second << std::endl;
-  pose3D tmp_pose({0.f, 0.f, 0.f}, {1.f, 0.f, 0.f, 0.f});
-  path.push_back(tmp_pose);
+//  std::cout << "[se/candview] best candidate is " << best_cand_pose_with_gain.first.p.format(InLine)
+//            << " yaw " << toEulerAngles(best_cand_pose_with_gain.first.q).yaw * 180.f / M_PI
+//            << " with gain " << best_cand_pose_with_gain.second << std::endl;
+  path.push_back(best_cand_pose_with_gain.first);
   for (const auto &pose : pose_gain) {
     cand_views.push_back(pose.first);
   }

--- a/se_shared/include/se/path_planning/candidate_view.hpp
+++ b/se_shared/include/se/path_planning/candidate_view.hpp
@@ -18,7 +18,7 @@
 #include <cmath>
 
 #include <Eigen/StdVector>
-
+#include "se/geometry/octree_collision.hpp"
 #include "se/continuous/volume_template.hpp"
 #include "se/octree.hpp"
 #include "se/node_iterator.hpp"
@@ -234,6 +234,8 @@ Eigen::Vector3i CandidateView<T>::getOffsetCandidate(const Eigen::Vector3i &cand
  Eigen::Vector3i bbox_sides = {offset_v*2, offset_v*2, offset_v*2};
   std::chrono::time_point<std::chrono::steady_clock> timings[3];
 
+  std::cout << "[se/candview] sphere center " << offset_cand_v.format(InLine) <<
+            " bbox corner " <<  bbox_corner.format(InLine) << std::endl;
   timings[0] = std::chrono::steady_clock::now();
   bool free_sphere = collision_check.isSphereCollisionFree(offset_cand_v);
 
@@ -244,26 +246,30 @@ Eigen::Vector3i CandidateView<T>::getOffsetCandidate(const Eigen::Vector3i &cand
       bbox_sides,
       test_voxel2);
   timings[2] = std::chrono::steady_clock::now();
+
+
   double sphere_time = std::chrono::duration_cast<std::chrono::duration<double> >(timings[1]
       -timings[0]).count();
   double bbox_time = std::chrono::duration_cast<std::chrono::duration<double> >(timings[2] -
       timings[1]).count();
   std::cout << "[se/cand view] sphere check time: " << sphere_time
-    << " collision " << free_sphere
+    << " collision free " << free_sphere
       << std::endl;
 
   std::cout << "[se/candview] bbox check time: " << bbox_time
-  << " collision " << bbox_status
+  << " collision free = 2 " << bbox_status
    << std::endl;
   if (sphere_time>bbox_time){
     std::cout << "\n[se/candview] sphere slower" <<std::endl;
   }
   if ((int)free_sphere != (int)bbox_status){
-    std::cout << "[se/candview] status not equal ";
+    std::cout << "[se/candview] status not equal " << std::endl;
     if(free_sphere==0){
       std::cout << "sphere check free and bbox check " << bbox_status << std::endl;
     }
   }
+
+
 
   if (is_valid) {
     if (free_sphere) {

--- a/se_shared/include/se/path_planning/candidate_view.hpp
+++ b/se_shared/include/se/path_planning/candidate_view.hpp
@@ -237,7 +237,7 @@ Eigen::Vector3i CandidateView<T>::getOffsetCandidate(const Eigen::Vector3i &cand
   std::cout << "[se/candview] sphere center " << offset_cand_v.format(InLine) <<
             " bbox corner " <<  bbox_corner.format(InLine) << std::endl;
   timings[0] = std::chrono::steady_clock::now();
-  bool free_sphere = collision_check.isSphereCollisionFree(offset_cand_v);
+  int free_sphere = collision_check.isSphereCollisionFree(offset_cand_v);
 
   timings[1] = std::chrono::steady_clock::now();
 
@@ -253,16 +253,14 @@ Eigen::Vector3i CandidateView<T>::getOffsetCandidate(const Eigen::Vector3i &cand
   double bbox_time = std::chrono::duration_cast<std::chrono::duration<double> >(timings[2] -
       timings[1]).count();
   std::cout << "[se/cand view] sphere check time: " << sphere_time
-    << " collision free " << free_sphere
-      << std::endl;
+    << " collision free = 1 " << free_sphere << std::endl;
 
   std::cout << "[se/candview] bbox check time: " << bbox_time
-  << " collision free = 2 " << bbox_status
-   << std::endl;
+  << " collision free = 2 " << bbox_status << std::endl;
   if (sphere_time>bbox_time){
     std::cout << "\n[se/candview] sphere slower" <<std::endl;
   }
-  if ((int)free_sphere != (int)bbox_status){
+  if (free_sphere != (int)bbox_status){
     std::cout << "[se/candview] status not equal " << std::endl;
     if(free_sphere==0){
       std::cout << "sphere check free and bbox check " << bbox_status << std::endl;
@@ -272,7 +270,7 @@ Eigen::Vector3i CandidateView<T>::getOffsetCandidate(const Eigen::Vector3i &cand
 
 
   if (is_valid) {
-    if (free_sphere) {
+    if (free_sphere==1.f) {
       return offset_cand_v;
     } else {
       // is valid but the sphere is not collision free

--- a/se_shared/include/se/path_planning/candidate_view.hpp
+++ b/se_shared/include/se/path_planning/candidate_view.hpp
@@ -228,46 +228,7 @@ Eigen::Vector3i CandidateView<T>::getOffsetCandidate(const Eigen::Vector3i &cand
             << " offset by " << offset_v << " results in " << offset_cand_v.x() << " "
             << offset_cand_v.y() << " " << offset_cand_v.z() << " voxel state "
             << volume_._map_index->get(offset_cand_v).st;*/
-
- Eigen::Vector3i corner_offset(offset_v, offset_v, offset_v);
- Eigen::Vector3i bbox_corner = offset_cand_v-corner_offset;
- Eigen::Vector3i bbox_sides = {offset_v*2, offset_v*2, offset_v*2};
-  std::chrono::time_point<std::chrono::steady_clock> timings[3];
-
-  std::cout << "[se/candview] sphere center " << offset_cand_v.format(InLine) <<
-            " bbox corner " <<  bbox_corner.format(InLine) << std::endl;
-  timings[0] = std::chrono::steady_clock::now();
   int free_sphere = collision_check.isSphereCollisionFree(offset_cand_v);
-
-  timings[1] = std::chrono::steady_clock::now();
-
-  se::geometry::collision_status bbox_status = se::geometry::collides_with(*volume_._map_index,
-      bbox_corner,
-      bbox_sides,
-      test_voxel2);
-  timings[2] = std::chrono::steady_clock::now();
-
-
-  double sphere_time = std::chrono::duration_cast<std::chrono::duration<double> >(timings[1]
-      -timings[0]).count();
-  double bbox_time = std::chrono::duration_cast<std::chrono::duration<double> >(timings[2] -
-      timings[1]).count();
-  std::cout << "[se/cand view] sphere check time: " << sphere_time
-    << " collision free = 1 " << free_sphere << std::endl;
-
-  std::cout << "[se/candview] bbox check time: " << bbox_time
-  << " collision free = 2 " << bbox_status << std::endl;
-  if (sphere_time>bbox_time){
-    std::cout << "\n[se/candview] sphere slower" <<std::endl;
-  }
-  if (free_sphere != (int)bbox_status){
-    std::cout << "[se/candview] status not equal " << std::endl;
-    if(free_sphere==0){
-      std::cout << "sphere check free and bbox check " << bbox_status << std::endl;
-    }
-  }
-
-
 
   if (is_valid) {
     if (free_sphere==1.f) {
@@ -593,9 +554,9 @@ void getExplorationPath(const Volume<T> &volume,
   VectorPairPoseDouble pose_gain = candidate_view.getCandidateGain(step);
 
   std::pair<pose3D, double> best_cand_pose_with_gain = candidate_view.getBestCandidate(pose_gain);
-/*  std::cout << "[se/candview] best candidate is " << best_cand_pose_with_gain.first.p.format(InLine)
+  std::cout << "[se/candview] best candidate is " << best_cand_pose_with_gain.first.p.format(InLine)
             << " yaw " << toEulerAngles(best_cand_pose_with_gain.first.q).yaw * 180.f / M_PI
-            << " with gain " << best_cand_pose_with_gain.second << std::endl;*/
+            << " with gain " << best_cand_pose_with_gain.second << std::endl;
   pose3D tmp_pose({0.f, 0.f, 0.f}, {1.f, 0.f, 0.f, 0.f});
   path.push_back(tmp_pose);
   for (const auto &pose : pose_gain) {

--- a/se_shared/include/se/path_planning/candidate_view.hpp
+++ b/se_shared/include/se/path_planning/candidate_view.hpp
@@ -232,7 +232,7 @@ Eigen::Vector3i CandidateView<T>::getOffsetCandidate(const Eigen::Vector3i &cand
  Eigen::Vector3i corner_offset(offset_v, offset_v, offset_v);
  Eigen::Vector3i bbox_corner = offset_cand_v-corner_offset;
  Eigen::Vector3i bbox_sides = {offset_v*2, offset_v*2, offset_v*2};
-  std::chrono::time_point<std::chrono::steady_clock> timings[2];
+  std::chrono::time_point<std::chrono::steady_clock> timings[3];
 
   timings[0] = std::chrono::steady_clock::now();
   bool free_sphere = collision_check.isSphereCollisionFree(offset_cand_v);
@@ -244,8 +244,10 @@ Eigen::Vector3i CandidateView<T>::getOffsetCandidate(const Eigen::Vector3i &cand
       bbox_sides,
       test_voxel2);
   timings[2] = std::chrono::steady_clock::now();
-  double sphere_time = std::chrono::duration<double>(timings[1] -timings[0]).count();
-  double bbox_time = std::chrono::duration<double>(timings[1] - timings[2]).count();
+  double sphere_time = std::chrono::duration_cast<std::chrono::duration<double> >(timings[1]
+      -timings[0]).count();
+  double bbox_time = std::chrono::duration_cast<std::chrono::duration<double> >(timings[2] -
+      timings[1]).count();
   std::cout << "[se/cand view] sphere check time: " << sphere_time
     << " collision " << free_sphere
       << std::endl;
@@ -256,6 +258,13 @@ Eigen::Vector3i CandidateView<T>::getOffsetCandidate(const Eigen::Vector3i &cand
   if (sphere_time>bbox_time){
     std::cout << "\n[se/candview] sphere slower" <<std::endl;
   }
+  if ((int)free_sphere != (int)bbox_status){
+    std::cout << "[se/candview] status not equal ";
+    if(free_sphere==0){
+      std::cout << "sphere check free and bbox check " << bbox_status << std::endl;
+    }
+  }
+
   if (is_valid) {
     if (free_sphere) {
       return offset_cand_v;

--- a/se_shared/include/se/path_planning/collision_checker.hpp
+++ b/se_shared/include/se/path_planning/collision_checker.hpp
@@ -51,9 +51,9 @@ CollisionCheck<T>::CollisionCheck(const VolumeTemplate<T, se::Octree> &volume,
 
 
 template<typename T>
-int CollisionCheck<T>::isSphereCollisionFree( const Eigen::Vector3i center) {
+int CollisionCheck<T>::isSphereCollisionFree(const Eigen::Vector3i center) {
 
-  int radius_v= static_cast<int>(planning_config_.cand_view_safety_radius/ res_); // m/(m/voxel)
+  int radius_v = static_cast<int>(planning_config_.cand_view_safety_radius / res_); // m/(m/voxel)
   se::Node<T> *node = nullptr;
   se::VoxelBlock<T> *block = nullptr;
   bool is_voxel_block;
@@ -69,8 +69,11 @@ int CollisionCheck<T>::isSphereCollisionFree( const Eigen::Vector3i center) {
           Eigen::Vector3i point_v = point_offset_v + center;
           // first round
           if (node == nullptr || block == nullptr) {
-            volume_._map_index->fetch_octant(point_v.x(), point_v.y(), point_v.z(), node,
-                is_voxel_block);
+            volume_._map_index->fetch_octant(point_v.x(),
+                                             point_v.y(),
+                                             point_v.z(),
+                                             node,
+                                             is_voxel_block);
             prev_pos = point_v;
             if (is_voxel_block) {
               block = static_cast<se::VoxelBlock<T> *> (node);
@@ -89,17 +92,20 @@ int CollisionCheck<T>::isSphereCollisionFree( const Eigen::Vector3i center) {
                 && ((point_v.z()) / BLOCK_SIDE) == (prev_pos.z() / BLOCK_SIDE)) {
               if (block->data(point_v).x >= 0.f) {
 //                std::cout << " [secollision] collision at " << point_v.format(InLine) << " plog "
-//                          << block->data(point_v) << std::endl;
+//                          << block->data(point_v).x << std::endl;
                 return 0;
               }
             } else {
-              volume_._map_index->fetch_octant(point_v.x(), point_v.y(), point_v.z(), node,
-                  is_voxel_block);
+              volume_._map_index->fetch_octant(point_v.x(),
+                                               point_v.y(),
+                                               point_v.z(),
+                                               node,
+                                               is_voxel_block);
               if (is_voxel_block) {
                 block = static_cast<se::VoxelBlock<T> *> (node);
                 if (block->data(point_v).x >= 0.f) {
 //                  std::cout << " [secollision] collision at " << point_v.format(InLine) << " plog "
-//                            << block->data(point_v) << std::endl;
+//                            << block->data(point_v).x << std::endl;
                   return 0;
                 }
               } else {

--- a/se_shared/include/se/path_planning/collision_checker.hpp
+++ b/se_shared/include/se/path_planning/collision_checker.hpp
@@ -51,13 +51,15 @@ CollisionCheck<T>::CollisionCheck(const VolumeTemplate<T, se::Octree> &volume,
 
 template<typename T>
 bool CollisionCheck<T>::isSphereCollisionFree(const Eigen::Vector3i pos_v) {
-  int radius_v = static_cast<int>(planning_config_.cand_view_safety_radius / res_); // m/(m/voxel)
+  int radius_v = static_cast<int>(planning_config_.cand_view_safety_radius / res_);// m/(m/voxel)
+  radius_v *=radius_v;
   for (int x = -radius_v; x <= radius_v; x++) {
     for (int y = -radius_v; y <= radius_v; y++) {
       for (int z = -radius_v; z <= radius_v; z++) {
         Eigen::Vector3i point_offset_v(x, y, z);
         //check if point is inside the sphere radius
-        if (point_offset_v.norm() <= radius_v) {
+        if (point_offset_v.squaredNorm() <= radius_v) {
+
 
           // check if voxelblock is allocated or only node
           Eigen::Vector3i point_v = point_offset_v + pos_v;

--- a/se_shared/include/se/path_planning/collision_checker.hpp
+++ b/se_shared/include/se/path_planning/collision_checker.hpp
@@ -78,35 +78,44 @@ bool CollisionCheck<T>::isSphereCollisionFree(const Eigen::Vector3i pos_v) {
             if (is_voxel_block) {
               block = static_cast<se::VoxelBlock<OFusion> *> (node);
             } else {
-              if (volume_._map_index->get(se::keyops::decode(node->code_)).x >= 0.f)
+              if (volume_._map_index->get(se::keyops::decode(node->code_)).x >= 0.f) {
+                std::cout << " [secollision] collision at node "
+                          << se::keyops::decode(node->code_).format(InLine) << std::endl;
                 return false;
+              }
             }
-          }
-          // if true keep old voxelblock pointer and fetch
-          // else get new voxel block
-          if (isSameBlock(point_v, prev_pos) && block != nullptr) {
-            std::cout << "[secollision] same block" << std::endl;
-            if (block->data(point_v).x >= 0.f) {
-              return false;
-            }
-          } else {
-            std::cout << "[secollision]  not same block" << std::endl;
-            volume_._map_index->fetch_octant(point_v.x(),
-                                             point_v.y(),
-                                             point_v.z(),
-                                             node,
-                                             is_voxel_block);
-            if (is_voxel_block) {
-              block = static_cast<se::VoxelBlock<OFusion> *> (node);
+          }else {
+            // if true keep old voxelblock pointer and fetch
+            // else get new voxel block
+            if (isSameBlock(point_v, prev_pos)) {
               if (block->data(point_v).x >= 0.f) {
+                std::cout << " [secollision] collision at " << point_v.format(InLine) << " plog "
+                          << block->data(point_v).x << std::endl;
                 return false;
               }
             } else {
-              block = nullptr;
-              if (volume_._map_index->get(se::keyops::decode(node->code_)).x >= 0.f)
-                return false;
-            }
+              volume_._map_index->fetch_octant(point_v.x(),
+                                               point_v.y(),
+                                               point_v.z(),
+                                               node,
+                                               is_voxel_block);
+              if (is_voxel_block) {
+                block = static_cast<se::VoxelBlock<OFusion> *> (node);
+                if (block->data(point_v).x >= 0.f) {
+                  std::cout << " [secollision] collision at " << point_v.format(InLine) << " plog "
+                            << block->data(point_v).x << std::endl;
+                  return false;
+                }
+              } else {
+                block = nullptr;
+                if (volume_._map_index->get(se::keyops::decode(node->code_)).x >= 0.f) {
+                  std::cout << " [secollision] collision at node "
+                            << se::keyops::decode(node->code_).format(InLine) << std::endl;
+                  return false;
+                }
+              }
 
+            }
           }
           prev_pos = point_v;
         }

--- a/se_shared/include/se/path_planning/exploration_utils.hpp
+++ b/se_shared/include/se/path_planning/exploration_utils.hpp
@@ -33,8 +33,7 @@ struct pose3D {
 };
 
 static inline std::ostream &operator<<(std::ostream &os, const pose3D &pose) {
-  return os << pose.p.x() << pose.p.y() << pose.p.z() <<
-  pose.q.x() << pose.q.y() << pose.q.z()
+  return os << pose.p.x() << pose.p.y() << pose.p.z() << pose.q.x() << pose.q.y() << pose.q.z()
             << pose.q.z();
 }
 static inline std::istream &operator>>(std::istream &input, pose3D &pose) {
@@ -55,7 +54,7 @@ struct eulerAngles {
 };
 
 // source https://cs.stanford.edu/~acoates/quaternion.h
- // TODO write tests
+// TODO write tests
 /**
  * @brief Euler Angles to Quaternion
  * @param yaw [rad]
@@ -79,15 +78,14 @@ static inline Eigen::Quaternionf toQuaternion(float yaw, float pitch, float roll
 
   Eigen::Quaternionf q;
   q.w() = cy * cp * cr + sy * sp * sr;
-  q.x() =cy * cp * sr - sy * sp * cr;
+  q.x() = cy * cp * sr - sy * sp * cr;
   q.y() = sy * cp * sr + cy * sp * cr;
   q.z() = sy * cp * cr - cy * sp * sr;
 
   return q;
 }
 
-static inline eulerAngles toEulerAngles(Eigen::Quaternionf q)
-{
+static inline eulerAngles toEulerAngles(Eigen::Quaternionf q) {
   eulerAngles angles;
 
   // roll (x-axis rotation)
@@ -113,28 +111,25 @@ static inline eulerAngles toEulerAngles(Eigen::Quaternionf q)
  * this quaternion.
  * @return Euler angles in roll-pitch-yaw order.
  */
-static inline eulerAngles toEulerAngles2(Eigen::Quaternionf q){
+static inline eulerAngles toEulerAngles2(Eigen::Quaternionf q) {
   eulerAngles euler;
   const static float PI_OVER_2 = M_PI * 0.5;
   const static float EPSILON = 1e-10;
   float sqw, sqx, sqy, sqz;
 
   // quick conversion to Euler angles to give tilt to user
-  sqw = q.w()*q.w();
-  sqx = q.x()*q.x();
-  sqy = q.y()* q.y();
+  sqw = q.w() * q.w();
+  sqx = q.x() * q.x();
+  sqy = q.y() * q.y();
   sqz = q.z() * q.z();
 
-  euler.pitch = asin(2.0 * (q.w()*q.y() - q.x() * q.z()));
+  euler.pitch = asin(2.0 * (q.w() * q.y() - q.x() * q.z()));
   if (PI_OVER_2 - fabs(euler.pitch) > EPSILON) {
-    euler.yaw = atan2(2.0 * (q.x() * q.y() + q.w()*q.z()),
-                     sqx - sqy - sqz + sqw);
-    euler.roll = atan2(2.0 * (q.w()*q.x() + q.y() * q.z()),
-                     sqw - sqx - sqy + sqz);
+    euler.yaw = atan2(2.0 * (q.x() * q.y() + q.w() * q.z()), sqx - sqy - sqz + sqw);
+    euler.roll = atan2(2.0 * (q.w() * q.x() + q.y() * q.z()), sqw - sqx - sqy + sqz);
   } else {
     // compute heading from local 'down' vector
-    euler.yaw = atan2(2*q.y() * q.z() - 2 * q.x() * q.w(),
-                     2* q.x() * q.z() + 2 * q.y() * q.w());
+    euler.yaw = atan2(2 * q.y() * q.z() - 2 * q.x() * q.w(), 2 * q.x() * q.z() + 2 * q.y() * q.w());
     euler.roll = 0.0;
 
     // If facing down, reverse yaw
@@ -160,10 +155,10 @@ static inline double getEntropy(float prob_log) {
 
 }
 
-static inline bool isSameBlock (Eigen::Vector3i voxel , Eigen::Vector3i face_voxel){
-  return (voxel.x()  / BLOCK_SIDE) == (face_voxel.x() / BLOCK_SIDE)
-          && ((voxel.y() ) / BLOCK_SIDE) == (face_voxel.y()  / BLOCK_SIDE)
-          && ((voxel.z() ) / BLOCK_SIDE) == (face_voxel.z() / BLOCK_SIDE);
+static inline bool isSameBlock(Eigen::Vector3i voxel, Eigen::Vector3i face_voxel) {
+  return (voxel.x() / BLOCK_SIDE) == (face_voxel.x() / BLOCK_SIDE)
+      && (voxel.y() / BLOCK_SIDE) == (face_voxel.y() / BLOCK_SIDE)
+      && (voxel.z() / BLOCK_SIDE) == (face_voxel.z() / BLOCK_SIDE);
 }
 
 } //exploration

--- a/se_shared/include/se/path_planning/exploration_utils.hpp
+++ b/se_shared/include/se/path_planning/exploration_utils.hpp
@@ -160,10 +160,10 @@ static inline double getEntropy(float prob_log) {
 
 }
 
-static inline int isSameBlock (Eigen::Vector3i voxel , Eigen::Vector3i face_voxel){
-  return ((voxel.x() + 1) / BLOCK_SIDE) == ((face_voxel.x() + 1) / BLOCK_SIDE)
-          && ((voxel.y() + 1) / BLOCK_SIDE) == ((face_voxel.y() + 1) / BLOCK_SIDE)
-          && ((voxel.z() + 1) / BLOCK_SIDE) == ((face_voxel.z() + 1) / BLOCK_SIDE);
+static inline bool isSameBlock (Eigen::Vector3i voxel , Eigen::Vector3i face_voxel){
+  return (voxel.x()  / BLOCK_SIDE) == (face_voxel.x() / BLOCK_SIDE)
+          && ((voxel.y() ) / BLOCK_SIDE) == (face_voxel.y()  / BLOCK_SIDE)
+          && ((voxel.z() ) / BLOCK_SIDE) == (face_voxel.z() / BLOCK_SIDE);
 }
 
 } //exploration

--- a/se_shared/include/se/path_planning/exploration_utils.hpp
+++ b/se_shared/include/se/path_planning/exploration_utils.hpp
@@ -159,6 +159,13 @@ static inline double getEntropy(float prob_log) {
   return temp_entropy;
 
 }
+
+static inline int isSameBlock (Eigen::Vector3i voxel , Eigen::Vector3i face_voxel){
+  return ((voxel.x() + 1) / BLOCK_SIDE) == ((face_voxel.x() + 1) / BLOCK_SIDE)
+          && ((voxel.y() + 1) / BLOCK_SIDE) == ((face_voxel.y() + 1) / BLOCK_SIDE)
+          && ((voxel.z() + 1) / BLOCK_SIDE) == ((face_voxel.z() + 1) / BLOCK_SIDE);
+}
+
 } //exploration
 }//namespace se
 #endif //SUPEREIGHT_EXPLORATION_UTILS_HPP


### PR DESCRIPTION
Candidate view generation: sphere check function is compared to the octree collision test function.
Result: sphere collision test outperforms the bounding box based collision test in 40 out of 50 cases.
- before the sphere check assumed all to be checked voxels to be allocated in voxel blocks. after, nodes are also treated
- before the bounding box treated unseen as an own case. After changes, unseen is  treated as occupied for path planning purposes.

- multiple unit tests are added for sphere check.