### PR TITLE
Add leaf level nodes to free and frontier volume

### DIFF
--- a/se_core/include/se/functors/data_handler.hpp
+++ b/se_core/include/se/functors/data_handler.hpp
@@ -52,6 +52,10 @@ class DataHandlerBase {
   };
   virtual bool isFrontier() {
   };
+
+  virtual key_t  get_mortoncode(){};
+
+  virtual int get_childidx(){};
 };
 
 template<typename FieldType>
@@ -130,6 +134,13 @@ class VoxelBlockHandler : DataHandlerBase<VoxelBlockHandler<FieldType>,
     return false;
   }
 
+  key_t  get_mortoncode(){
+    return _block->code_;
+  }
+// only for nodes
+  int get_childidx(){
+    return -1;
+  };
  private:
   se::VoxelBlock<FieldType> *_block;
   Eigen::Vector3i _voxel;
@@ -164,6 +175,13 @@ class NodeHandler : DataHandlerBase<NodeHandler<FieldType>, se::Node<FieldType> 
     return false;
   }
 
+  key_t  get_mortoncode(){
+    return _node->code_;
+  };
+
+  int get_childidx(){
+    return _idx;
+  }
  private:
   se::Node<FieldType> *_node;
   int _idx;

--- a/se_core/include/se/functors/data_handler.hpp
+++ b/se_core/include/se/functors/data_handler.hpp
@@ -53,11 +53,13 @@ class DataHandlerBase {
   virtual bool isFrontier() {
   };
 
-  virtual key_t  get_mortoncode(){};
+  virtual key_t  get_morton_code(){};
 
-  virtual int get_childidx(){};
+  virtual int get_child_idx(){};
 
   virtual NodeT * get_node(){};
+
+  virtual Eigen::Vector3i get_child_coord(){};
 };
 
 template<typename FieldType>
@@ -136,17 +138,21 @@ class VoxelBlockHandler : DataHandlerBase<VoxelBlockHandler<FieldType>,
     return false;
   }
 
-  key_t  get_mortoncode(){
+  key_t  get_morton_code(){
     return _block->code_;
   }
 // only for nodes
-  int get_childidx(){
+  int get_child_idx(){
     return -1;
   };
 
   se::VoxelBlock<FieldType> * get_node(){
     return _block;
   }
+
+  Eigen::Vector3i get_child_coord(){
+    return _block->coordinates();
+  };
  private:
   se::VoxelBlock<FieldType> *_block;
   Eigen::Vector3i _voxel;
@@ -181,16 +187,20 @@ class NodeHandler : DataHandlerBase<NodeHandler<FieldType>, se::Node<FieldType> 
     return false;
   }
 
-  key_t  get_mortoncode(){
+  key_t  get_morton_code(){
     return _node->code_;
   };
 
-  int get_childidx(){
+  int get_child_idx(){
     return _idx;
   }
 
   se::Node<FieldType> * get_node(){
     return  _node;
+  }
+
+  Eigen::Vector3i get_child_coord() {
+   return _node->childCoordinates(_idx);
   }
 
  private:

--- a/se_core/include/se/functors/data_handler.hpp
+++ b/se_core/include/se/functors/data_handler.hpp
@@ -219,7 +219,8 @@ class NodeHandler : DataHandlerBase<NodeHandler<FieldType>, se::Node<FieldType> 
   // returns the morton code of this node.
 
   key_t get_morton_code() {
-    const int level = se::keyops::level(_node->code_) + 1;
+    const int level = se::keyops::level(_node->code_) + 1; // level of the node which is being
+    // updated
     // TODO find a way to pass max_level around or make it constant
     const int max_level = 7;
     const Eigen::Vector3i octant_coord = getNodeCoordinates();

--- a/se_core/include/se/functors/data_handler.hpp
+++ b/se_core/include/se/functors/data_handler.hpp
@@ -106,7 +106,7 @@ class VoxelBlockHandler : DataHandlerBase<VoxelBlockHandler<FieldType>,
 
       // map boarder check, don't want the drone to fly there.
       if(face_voxel.x() < 0|| face_voxel.y() < 0 || face_voxel.z() <0 ||
-      face_voxel.x()>map.size() || face_voxel.y() > map.size() || face_voxel.z() > map.size()){
+      face_voxel.x() >= map.size() || face_voxel.y() >= map.size() || face_voxel.z() >= map.size()){
         return false;
       }
 
@@ -137,9 +137,9 @@ class VoxelBlockHandler : DataHandlerBase<VoxelBlockHandler<FieldType>,
 
         } else {
           // get parent node and get idx of this node to get value
-          key_t octant = se::keyops::encode(face_voxel.x(), face_voxel.y(), face_voxel.z(),
+          const key_t octant = se::keyops::encode(face_voxel.x(), face_voxel.y(), face_voxel.z(),
               map.leaf_level(), map.max_level());
-          int idx = se::child_id(octant, map.leaf_level(), map.max_level());
+          const int idx = se::child_id(octant, map.leaf_level(), map.max_level());
           // in case the neighbour node is also not in the same parent
           if (node->data(idx).st == voxel_state::kUnknown)
             return true;
@@ -197,16 +197,16 @@ class NodeHandler : DataHandlerBase<NodeHandler<FieldType>, se::Node<FieldType> 
    */
   bool isFrontier(const se::Octree<FieldType> &map) {
     // find out at which level the node is
-    key_t morton_parent = _node->code_;
-    Eigen::Vector3i coord = _node->childCoordinates(_idx);
-    int level_parent = se::keyops::level(morton_parent);
+    const key_t morton_parent = _node->code_;
+    const Eigen::Vector3i coord = _node->childCoordinates(_idx);
+    const int level_parent = se::keyops::level(morton_parent);
     int side_parent = _node->side_;
     int level_leaf = level_parent;
     while (side_parent != BLOCK_SIDE) {
       side_parent = side_parent >> 1;
       level_leaf++;
     }
-    int scale = level_leaf - level_parent;
+    const int scale = level_leaf - level_parent;
 
     // when this node is a leaf node , we only want to have frontiers at the higher resolution /
     // voxel level
@@ -230,7 +230,7 @@ class NodeHandler : DataHandlerBase<NodeHandler<FieldType>, se::Node<FieldType> 
       const int neighbor_z = coord.z() + scale * BLOCK_SIDE * se::face_neighbor_offsets[i].z();
       // map boarder check, don't want the drone to fly there.
       if(neighbor_x < 0|| neighbor_y  < 0 || neighbor_z < 0||
-          neighbor_x>map.size() || neighbor_y > map.size() || neighbor_z > map.size()){
+          neighbor_x >= map.size() || neighbor_y >= map.size() || neighbor_z >= map.size()){
         return false;
       }
       // neighbour voxelblock is not allocated

--- a/se_core/include/se/functors/data_handler.hpp
+++ b/se_core/include/se/functors/data_handler.hpp
@@ -56,6 +56,8 @@ class DataHandlerBase {
   virtual key_t  get_mortoncode(){};
 
   virtual int get_childidx(){};
+
+  virtual NodeT * get_node(){};
 };
 
 template<typename FieldType>
@@ -141,6 +143,10 @@ class VoxelBlockHandler : DataHandlerBase<VoxelBlockHandler<FieldType>,
   int get_childidx(){
     return -1;
   };
+
+  se::VoxelBlock<FieldType> * get_node(){
+    return _block;
+  }
  private:
   se::VoxelBlock<FieldType> *_block;
   Eigen::Vector3i _voxel;
@@ -182,6 +188,11 @@ class NodeHandler : DataHandlerBase<NodeHandler<FieldType>, se::Node<FieldType> 
   int get_childidx(){
     return _idx;
   }
+
+  se::Node<FieldType> * get_node(){
+    return  _node;
+  }
+
  private:
   se::Node<FieldType> *_node;
   int _idx;

--- a/se_core/include/se/functors/data_handler.hpp
+++ b/se_core/include/se/functors/data_handler.hpp
@@ -102,7 +102,6 @@ class VoxelBlockHandler : DataHandlerBase<VoxelBlockHandler<FieldType>,
     face_neighbour_voxel[3] << _voxel.x(), _voxel.y() + 1, _voxel.z();
     face_neighbour_voxel[4] << _voxel.x(), _voxel.y(), _voxel.z() - 1;
     face_neighbour_voxel[5] << _voxel.x(), _voxel.y(), _voxel.z() + 1;
-//    std::cout << "[se/datahandler] vb handler voxel " << _voxel.format(InLine);
     for (const auto &face_voxel : face_neighbour_voxel) {
 
       // map boarder check, don't want the drone to fly there.
@@ -116,7 +115,6 @@ class VoxelBlockHandler : DataHandlerBase<VoxelBlockHandler<FieldType>,
           && (_voxel.y() / BLOCK_SIDE) == (face_voxel.y() / BLOCK_SIDE)
           && (_voxel.z() / BLOCK_SIDE) == (face_voxel.z() / BLOCK_SIDE)) {
         // CASE 1: same voxel block
-//        std::cout << " same block block data "<< face_voxel.format(InLine)<<  std::endl;
         if (_block->data(face_voxel).st == voxel_state::kUnknown)
 
           return true;
@@ -124,25 +122,24 @@ class VoxelBlockHandler : DataHandlerBase<VoxelBlockHandler<FieldType>,
         // not same voxel block => check if neighbour is a voxel block
         se::Node<FieldType> *node = nullptr;
         bool is_voxel_block;
-//        std::cout << " not same vb fetch octant"<< std::endl;
         map.fetch_octant(face_voxel(0), face_voxel(1), face_voxel(2), node, is_voxel_block);
        // CASE 2: not same voxelblock but is a voxel
         if (is_voxel_block) {
           // neighbour is a voxel block
           se::VoxelBlock<FieldType> *block = static_cast<se::VoxelBlock<FieldType> *> (node);
-//          std::cout<< " is block get face_voxel" << std::endl;
           if (block->data(face_voxel).st == voxel_state::kUnknown)
             return true;
 
         // CASE 3: not same voxelblock but belongs to a node
         // TODO take value from node or say the curr voxel is unknown?
+        // currently just take node state
+        // the node can be at a much higher level
 
         } else {
           // get parent node and get idx of this node to get value
           key_t octant = se::keyops::encode(face_voxel.x(), face_voxel.y(), face_voxel.z(),
               map.leaf_level(), map.max_level());
           int idx = se::child_id(octant, map.leaf_level(), map.max_level());
-//        std::cout << " is node, get value "<< node->data(idx).st << std::endl;
           // in case the neighbour node is also not in the same parent
           if (node->data(idx).st == voxel_state::kUnknown)
             return true;
@@ -222,7 +219,7 @@ class NodeHandler : DataHandlerBase<NodeHandler<FieldType>, se::Node<FieldType> 
 //    std::cout << " level leaf " << level_leaf << " side parent after " << side_parent << " scale "
 //              << scale << std::endl;
 
-// TODO handling frontier nodes at higher level than
+// TODO handling frontier nodes at higher level than leaf level
     if (scale > 1 && level_parent + 1 != level_leaf) {
       return false;
     }
@@ -238,8 +235,8 @@ class NodeHandler : DataHandlerBase<NodeHandler<FieldType>, se::Node<FieldType> 
       }
       // neighbour voxelblock is not allocated
       if (map.fetch_octant(neighbor_x, neighbor_y, neighbor_z, level_parent + 1) == nullptr) {
-        std::cout << "[se/datahandler] " << coord.format(InLine) << " is frontier " << neighbor_x
-                  << " " << neighbor_y << " " << neighbor_z << std::endl;
+//        std::cout << "[se/datahandler] " << coord.format(InLine) << " is frontier " << neighbor_x
+//                  << " " << neighbor_y << " " << neighbor_z << std::endl;
         return true;
       }
     }

--- a/se_core/include/se/node.hpp
+++ b/se_core/include/se/node.hpp
@@ -103,10 +103,6 @@ public:
   void occupancyUpdated(const bool o) { occupancyUpdated_ = o; }
   bool occupancyUpdated() { return occupancyUpdated_; }
 
-  int get_node_idx(const int x, const int y, const int z, const int edge){
-   return ((x & edge) > 0) + 2 * ((y & edge) > 0) +
-       4 * ((z &edge) >0);
-  }
 
 protected:
     Node *child_ptr_[8];

--- a/se_core/include/se/node.hpp
+++ b/se_core/include/se/node.hpp
@@ -101,6 +101,10 @@ public:
   void occupancyUpdated(const bool o) { occupancyUpdated_ = o; }
   bool occupancyUpdated() { return occupancyUpdated_; }
 
+  int get_node_idx(const int x, const int y, const int z, const int edge){
+   return ((x & edge) > 0) + 2 * ((y & edge) > 0) +
+       4 * ((z &edge) >0);
+  }
 
 protected:
     Node *child_ptr_[8];

--- a/se_core/include/se/node.hpp
+++ b/se_core/include/se/node.hpp
@@ -85,7 +85,9 @@ public:
   Node *& child(const int offset ){
     return child_ptr_[offset];
   }
-
+  value_type data(const int offset)const{
+    return value_[offset];
+  }
   virtual bool isLeaf(){ return false; }
 /**
  *

--- a/se_core/include/se/node.hpp
+++ b/se_core/include/se/node.hpp
@@ -32,16 +32,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef NODE_H
 #define NODE_H
 
-#include <time.h>
 #include <atomic>
-#include <se/volume_traits.hpp>
+#include <ctime>
+#include <Eigen/Dense>
+
+#include "se/volume_traits.hpp"
 #include "voxel_traits.hpp"
 #include "octree_defines.h"
 #include "utils/math_utils.h"
 #include "utils/memory_pool.hpp"
+#include "utils/eigen_utils.h"
 #include "io/se_serialise.hpp"
 
-namespace se { 
+namespace se {
 template <typename T>
 class Node {
 
@@ -57,6 +60,10 @@ public:
   key_t code_;
   unsigned int side_;
   unsigned char children_mask_;
+
+  const Eigen::Vector3i child_offsets_[8] =
+      {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {1, 1, 0},
+       {0, 0, 1}, {1, 0, 1}, {0, 1, 1}, {1, 1, 1}};
 
   Node(){
     code_ = 0;
@@ -80,6 +87,16 @@ public:
   }
 
   virtual bool isLeaf(){ return false; }
+/**
+ *
+ * @param offset = idx
+ * @return bottom left corner coordinate of the node
+ */
+  Eigen::Vector3i childCoordinates(const int offset) const {
+    // Get the Node coordinates from the Morton code and add the child
+    // offset.
+    return keyops::decode(code_) + (side_ >> 1) * child_offsets_[offset];
+  }
 
   void occupancyUpdated(const bool o) { occupancyUpdated_ = o; }
   bool occupancyUpdated() { return occupancyUpdated_; }

--- a/se_core/include/se/node.hpp
+++ b/se_core/include/se/node.hpp
@@ -32,11 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef NODE_H
 #define NODE_H
 
+#include <time.h>
 #include <atomic>
-#include <ctime>
-
-#include <Eigen/Dense>
-
 #include <se/volume_traits.hpp>
 #include "voxel_traits.hpp"
 #include "octree_defines.h"
@@ -44,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "utils/memory_pool.hpp"
 #include "io/se_serialise.hpp"
 
-namespace se {
+namespace se { 
 template <typename T>
 class Node {
 
@@ -60,10 +57,6 @@ public:
   key_t code_;
   unsigned int side_;
   unsigned char children_mask_;
-
-  const Eigen::Vector3i child_offsets_[8] =
-      {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {1, 1, 0},
-       {0, 0, 1}, {1, 0, 1}, {0, 1, 1}, {1, 1, 1}};
 
   Node(){
     code_ = 0;
@@ -87,12 +80,6 @@ public:
   }
 
   virtual bool isLeaf(){ return false; }
-
-  Eigen::Vector3i childCoordinates(const int offset) const {
-    // Get the Node coordinates from the Morton code and add the child
-    // offset.
-    return keyops::decode(code_) + (side_ >> 1) * child_offsets_[offset];
-  }
 
   void occupancyUpdated(const bool o) { occupancyUpdated_ = o; }
   bool occupancyUpdated() { return occupancyUpdated_; }

--- a/se_core/include/se/node_iterator.hpp
+++ b/se_core/include/se/node_iterator.hpp
@@ -249,21 +249,22 @@ class node_iterator {
     const Eigen::Vector3i blockCoord = keyops::decode(morton);
     Node<T> *node = nullptr;
     bool is_block = false;
+    // returned node could be at any level, but currently only frontier node at leaf level
     map_.fetch_octant(blockCoord(0), blockCoord(1), blockCoord(2), node, is_block);
 
     if (!is_block) {
       // data handler set parent_node ->value[idx];
+      // TODO include when we consider frontier nodes at lower than leaf level
       const int level = keyops::level(morton);
-      Node<T> *parent_node =
-          map_.fetch_octant(blockCoord.x(), blockCoord.y(), blockCoord.z(), level - 1);
-      const int edge = (map_.leaf_level()-level ) * BLOCK_SIDE;
-      const int idx = ((blockCoord.x() & edge) > 0) + 2 * ((blockCoord.y() & edge) > 0)
-          + 4 * ((blockCoord.z() & edge) > 0);
+//      Node<T> *parent_node =
+//          map_.fetch_octant(blockCoord.x(), blockCoord.y(), blockCoord.z(), level - 1);
+//      const int edge = (map_.leaf_level()-level ) * BLOCK_SIDE;
+//      const int idx = ((blockCoord.x() & edge) > 0) + 2 * ((blockCoord.y() & edge) > 0)
+//          + 4 * ((blockCoord.z() & edge) > 0);
       const int childid = child_id(morton, level, map_.max_level());
 
-      NodeHandler<T> handler = {parent_node, idx}; // pointer to parent node and idx of this node
-      std::cout << "[se/delete frontier] side length " << edge << "idx" << idx
-      << " childid" << childid << std::endl;
+//      NodeHandler<T> handler = {parent_node, idx}; // pointer to parent node and idx of this node
+      NodeHandler<T> handler = {node, childid}; // pointer to parent node and idx of this node
       auto data = handler.get();
 
       if (data.st == voxel_state::kFrontier && !handler.isFrontier(map_)) {

--- a/se_core/include/se/node_iterator.hpp
+++ b/se_core/include/se/node_iterator.hpp
@@ -183,6 +183,7 @@ class node_iterator {
     bool is_block = false;
     map_.fetch_octant(blockCoord(0), blockCoord(1), blockCoord(2), node, is_block);
     if (!is_block) {
+      std::cout << " node frontier " << blockCoord.format(InLine) << std::endl;
       frontierVoxels.push_back(blockCoord);
       frontierVoxels.push_back(Eigen::Vector3i(0, 0, 0));
     } else {
@@ -208,11 +209,11 @@ class node_iterator {
     return frontierVoxels;
   }
 
-  /**
-   * check if frontier voxels are in the voxel block
-   * @param blockCoord
-   * @return
-   */
+/**
+ * check if frontier voxels are in the voxel block
+ * @param blockCoord
+ * @return
+ */
   bool hasFrontierVoxelBlockviaMorton(const Eigen::Vector3i &blockCoord) {
 
 //    VoxelBlock<T>* block = map_.fetch(blockCoord(0), blockCoord(1), blockCoord(2));
@@ -236,42 +237,77 @@ class node_iterator {
 
     return false;
   }
-  /**
-   * update all frontier voxels, targeting the frontier voxel just above floor
-   * @param blockCoord bottom left voxel block (node) voxel
-   * @return
-   */
-  bool deleteFrontierVoxelBlockviaMorton(const Eigen::Vector3i &blockCoord) {
+/**
+ * update all frontier voxels, targeting the frontier voxel just above floor
+ * @param blockCoord bottom left voxel block (node) voxel
+ * @return
+ */
+  bool deleteFrontierVoxelBlockviaMorton(const int64_t morton) {
 //    VoxelBlock<T>* block = map_.fetch(blockCoord(0), blockCoord(1), blockCoord(2));
     bool has_frontier = false;
 
-    const int xlast = blockCoord(0) + BLOCK_SIDE;
-    const int ylast = blockCoord(1) + BLOCK_SIDE;
-    const int zlast = blockCoord(2) + BLOCK_SIDE;
-    se::VoxelBlock<T> *block = map_.fetch(blockCoord(0), blockCoord(1), blockCoord(2));
-    for (int z = blockCoord(2); z < zlast; ++z) {
-      for (int y = blockCoord(1); y < ylast; ++y) {
-        for (int x = blockCoord(0); x < xlast; ++x) {
-          // make handler with the current voxel
-          VoxelBlockHandler<T> handler = {block, Eigen::Vector3i(x, y, z)};
-          auto data = handler.get();
-//          std::cout << "[se/node_it] state "<< map_.get(x,y,z).st << std::endl;
-          if (map_.get(x, y, z).st == voxel_state::kFrontier && !handler.isFrontier(map_)) {
-//            std::cout << " [supereight/node it] voxel is a frontier" << std::endl;
-            // check for the curr voxel if it a Frontier / has an unknown voxel next to it
-            if (data.x <= THRESH_FREE) {
-              data.st = voxel_state::kFree;
+    const Eigen::Vector3i blockCoord = keyops::decode(morton);
+    Node<T> *node = nullptr;
+    bool is_block = false;
+    map_.fetch_octant(blockCoord(0), blockCoord(1), blockCoord(2), node, is_block);
+
+    if (!is_block) {
+      // data handler set parent_node ->value[idx];
+      const int level = keyops::level(morton);
+      Node<T> *parent_node =
+          map_.fetch_octant(blockCoord.x(), blockCoord.y(), blockCoord.z(), level - 1);
+      const int edge = (map_.leaf_level()-level ) * BLOCK_SIDE;
+      const int idx = ((blockCoord.x() & edge) > 0) + 2 * ((blockCoord.y() & edge) > 0)
+          + 4 * ((blockCoord.z() & edge) > 0);
+      const int childid = child_id(morton, level, map_.max_level());
+
+      NodeHandler<T> handler = {parent_node, idx}; // pointer to parent node and idx of this node
+      std::cout << "[se/delete frontier] side length " << edge << "idx" << idx
+      << " childid" << childid << std::endl;
+      auto data = handler.get();
+
+      if (data.st == voxel_state::kFrontier && !handler.isFrontier(map_)) {
+        if (data.x <= THRESH_FREE) {
+          data.st = voxel_state::kFree;
 //              std::cout << "[superegiht/node_it] frontier=> free , voxel " << x << " " << y << " "
 //                        << z << std::endl;
-            } else if (data.x >= THRESH_OCC) {
-              data.st = voxel_state::kOccupied;
+        } else if (data.x >= THRESH_OCC) {
+          data.st = voxel_state::kOccupied;
+        }
+        handler.set(data);
+
+      } else if (handler.isFrontier(map_)) {
+        has_frontier = true;
+      }
+    } else {
+      VoxelBlock<T> *block = static_cast< VoxelBlock<T> *> (node);
+      const int xlast = blockCoord(0) + BLOCK_SIDE;
+      const int ylast = blockCoord(1) + BLOCK_SIDE;
+      const int zlast = blockCoord(2) + BLOCK_SIDE;
+      for (int z = blockCoord(2); z < zlast; ++z) {
+        for (int y = blockCoord(1); y < ylast; ++y) {
+          for (int x = blockCoord(0); x < xlast; ++x) {
+            // make handler with the current voxel
+            VoxelBlockHandler<T> handler = {block, Eigen::Vector3i(x, y, z)};
+            auto data = handler.get();
+//          std::cout << "[se/node_it] state "<< map_.get(x,y,z).st << std::endl;
+            if (data.st == voxel_state::kFrontier && !handler.isFrontier(map_)) {
+//            std::cout << " [supereight/node it] voxel is a frontier" << std::endl;
+              // check for the curr voxel if it a Frontier / has an unknown voxel next to it
+              if (data.x <= THRESH_FREE) {
+                data.st = voxel_state::kFree;
+//              std::cout << "[superegiht/node_it] frontier=> free , voxel " << x << " " << y << " "
+//                        << z << std::endl;
+              } else if (data.x >= THRESH_OCC) {
+                data.st = voxel_state::kOccupied;
+              }
+              handler.set(data);
+
+            } else if (handler.isFrontier(map_)) {
+              has_frontier = true;
             }
-            handler.set(data);
 
-          } else if (handler.isFrontier(map_)) {
-            has_frontier = true;
           }
-
         }
       }
     }

--- a/se_core/include/se/octree.hpp
+++ b/se_core/include/se/octree.hpp
@@ -491,6 +491,7 @@ void Octree<T>::init(int size, float dim) {
   std::memset(keys_at_level_, 0, reserved_);
 }
 
+// returned node could be at any level
 template<typename T>
 inline void Octree<T>::fetch_octant(const int x, const int y, const int z, Node<T>* &pointer,
     bool &voxelblock)
@@ -509,7 +510,6 @@ const {
     Node<T> *tmp  = n->child((x & edge) > 0u, (y & edge) > 0u, (z & edge) > 0u);
     if (!tmp) {
       pointer = n;
-
       return ;
     }
     n= tmp;
@@ -543,6 +543,7 @@ inline VoxelBlock<T> *Octree<T>::fetch(const int x, const int y, const int z) co
   }
   return static_cast<VoxelBlock<T> * > (n);
 }
+// returns the octant at the given level
 
 template<typename T>
 inline Node<T> *Octree<T>::fetch_octant(const int x,
@@ -559,6 +560,7 @@ inline Node<T> *Octree<T>::fetch_octant(const int x,
   unsigned edge = size_ / 2;
   for (int d = 1; edge >= blockSide && d <= depth; edge /= 2, ++d) {
     n = n->child((x & edge) > 0u, (y & edge) > 0u, (z & edge) > 0u);
+    // node not allocated at the input level
     if (!n) {
       return NULL;
     }

--- a/se_core/include/se/octree.hpp
+++ b/se_core/include/se/octree.hpp
@@ -522,7 +522,7 @@ const {
 
 template<typename T>
 inline VoxelBlock<T> *Octree<T>::fetch(const uint64_t morton) const {
- Eigen::Vector3i coord = unpack_morton(morton);
+ Eigen::Vector3i coord = se::keyops::decode(morton);
  return fetch(coord.x(), coord.y(), coord.z());
 }
 template<typename T>

--- a/se_core/include/se/octree.hpp
+++ b/se_core/include/se/octree.hpp
@@ -73,7 +73,8 @@ class Octree {
   typedef typename traits_type::value_type value_type;
   value_type empty() const { return traits_type::empty(); }
   value_type init_val() const { return traits_type::initValue(); }
-
+  inline int max_level() const { return max_level_; }
+  inline int leaf_level() const{ return leaf_level_; }
   // Compile-time constant expressions
   // # of voxels per side in a voxel block
   static constexpr unsigned int blockSide = BLOCK_SIDE;
@@ -253,6 +254,7 @@ class Octree {
   int size_;
   float dim_;
   int max_level_;
+  int leaf_level_;
   MemoryPool<VoxelBlock<T> > block_buffer_;
   MemoryPool<Node<T> > nodes_buffer_;
 
@@ -480,6 +482,7 @@ void Octree<T>::init(int size, float dim) {
   size_ = size;
   dim_ = dim;
   max_level_ = log2(size);
+  leaf_level_ = max_level_ - math::log2_const(blockSide);
   nodes_buffer_.reserve(1);
   root_ = nodes_buffer_.acquire_block();
   root_->side_ = size;

--- a/se_denseslam/include/se/boundary_extraction.hpp
+++ b/se_denseslam/include/se/boundary_extraction.hpp
@@ -19,12 +19,11 @@ template<typename T> using Volume = VolumeTemplate<T, se::Octree>;
 
 
 void insertBlocksToMap(map3i &blocks_map, set3i *blocks) {
-  if (blocks->size() == 0) {
-    return;
-  }
+  if (blocks->size() == 0) return;
+
 
   for (auto it = blocks->begin(); it != blocks->end(); ++it) {
-    Eigen::Vector3i voxel_coord = se::keyops::decode(*it);
+    const Eigen::Vector3i voxel_coord = se::keyops::decode(*it);
     blocks_map.emplace(*it, voxel_coord);
   }
 //  std::cout << "[supereight/boundary] frontier maps size " << blocks_map.size() << std::endl;

--- a/se_denseslam/include/se/boundary_extraction.hpp
+++ b/se_denseslam/include/se/boundary_extraction.hpp
@@ -24,14 +24,14 @@ void insertBlocksToMap(map3i &blocks_map, set3i *blocks) {
   }
 
   for (auto it = blocks->begin(); it != blocks->end(); ++it) {
-    Eigen::Vector3i voxel_coord = unpack_morton(*it);
+    Eigen::Vector3i voxel_coord = se::keyops::decode(*it);
     blocks_map.emplace(*it, voxel_coord);
   }
-  std::cout << "[supereight/boundary] frontier maps size " << blocks_map.size() << std::endl;
+//  std::cout << "[supereight/boundary] frontier maps size " << blocks_map.size() << std::endl;
 }
 /**
  * check if past frontier voxels have been updated and update the std::map
- * via voxel blocks / its morton code
+ * [uint64_t morton_code, Eigen::Vector3i coord]
  * TODO how to use OMP
  * Issue map wide function
  */
@@ -43,7 +43,7 @@ void updateFrontierMap(const Volume<T> &volume, map3i &frontier_blocks_map) {
   for (auto it = frontier_blocks_map.begin(); it != frontier_blocks_map.end(); ++it) {
     // check if the occupancy probability of the frontier voxels has been updated
     // changes voxel states from frontier to free or occupied
-    if (!node_it.deleteFrontierVoxelBlockviaMorton(it->second)) {
+    if (!node_it.deleteFrontierVoxelBlockviaMorton(it->first)) {
 //      std::cout << "[supereight/boundary] no frontier in voxel block => erase" << std::endl;
       frontier_blocks_map.erase(it->first);
     }

--- a/se_denseslam/src/bfusion/mapping_impl.hpp
+++ b/se_denseslam/src/bfusion/mapping_impl.hpp
@@ -261,17 +261,30 @@ struct bfusion_update {
 
     const bool is_voxel = std::is_same<DataHandlerT, VoxelBlockHandler<FieldType>>::value;
 
+    // TODO addis voxel flag
+
+
     const key_t morton_code_parent_node = handler.get_morton_code(); // parent node morton code
-    const int level_child = se::keyops::level(morton_code_parent_node) + 1;
+
+    const int level_child = se::keyops::level(morton_code_parent_node) ;
     // TODO find a way to pass max_level around or make it constant
     const int max_level = 7;
-    const Eigen::Vector3i child_coord = handler.get_child_coord();
+    const Eigen::Vector3i octant_coord = handler.getNodeCoordinates();
     // compute morton code of current node / voxelblock
-    const key_t morton_code_child = se::keyops::encode(child_coord.x(),
-                                                child_coord.y(),
-                                                child_coord.z(),
+    const key_t morton_code_via_handler = se::keyops::encode(octant_coord.x(),
+                                                octant_coord.y(),
+                                                octant_coord.z(),
                                                 level_child,
                                                 max_level);
+    const key_t morton_code_child = handler.get_morton_code();
+    if(morton_code_child!=morton_code_via_handler && !is_voxel){
+      std::cout << "handler and encode not equal encode " << morton_code_child <<
+      " handler " << morton_code_via_handler <<
+      std::endl;
+      std::cout << "octant coord " << octant_coord.format(InLine) << " decode encoded " <<
+      se::keyops::decode(morton_code_child).format(InLine) << ", decode handler  " <<
+      se::keyops::decode(morton_code_via_handler).format(InLine) << std::endl;
+    }
     // invalid depth measurement
     if (depthSample <= 0) {
       return;
@@ -327,8 +340,25 @@ struct bfusion_update {
           // conservative estimate as the occupancy probability for a free voxel is set quite low
           if (handler.isFrontier(map) && data.st == voxel_state::kFree) {
 //            std::cout << "is frontier " << data.st << std::endl;
-            frontier_blocks_->insert(morton_code_child);
-            data.st = voxel_state::kFrontier;
+            if(is_voxel) {
+              frontier_blocks_->insert(morton_code_child);
+              data.st = voxel_state::kFrontier;
+            } else{
+              se::Node<FieldType> * node_tmp = handler.get_node();
+              bool is_leaf = node_tmp->child(handler.get_child_idx())->isLeaf();
+              std::cout << "[se/mapping] frontier block but not added, this node is a leaf " <<
+              is_leaf << " with the coord " << handler.getNodeCoordinates() << std::endl;
+               auto p = std::find(frontier_blocks_->begin(), frontier_blocks_->end(),
+                   morton_code_child);
+               if(p!= frontier_blocks_->end()){
+                 std::cout << "node morton code was in frontier set via voxelblock update" <<
+                 std::endl;
+
+               } else{
+                 std::cout << "node morton code was not in set" << std::endl;
+               }
+
+            }
           }
         }
         handler.set(data);

--- a/se_denseslam/src/bfusion/mapping_impl.hpp
+++ b/se_denseslam/src/bfusion/mapping_impl.hpp
@@ -32,17 +32,17 @@
 #ifndef BFUSION_MAPPING_HPP
 #define BFUSION_MAPPING_HPP
 #include <cstdlib>
-#include <se/node.hpp>
 #include <Eigen/StdVector>
-#include <se/functors/projective_functor.hpp>
-#include <se/constant_parameters.h>
-#include <se/image/image.hpp>
-#include "bspline_lookup.cc"
 #include <atomic>
 #include <omp.h>
-
 #include <map>
-#include <se/octant_ops.hpp>
+
+#include "se/functors/projective_functor.hpp"
+#include "se/node.hpp"
+#include "se/constant_parameters.h"
+#include "se/image/image.hpp"
+#include "bspline_lookup.cc"
+#include "se/octant_ops.hpp"
 /**
  * Perform bilinear interpolation on a depth image. See
  * https://en.wikipedia.org/wiki/Bilinear_interpolation for more details.
@@ -259,10 +259,19 @@ struct bfusion_update {
     auto data = handler.get();
     float prev_occ = se::math::getProbFromLog(data.x);
 
-    Eigen::Vector3i coord = handler.getNodeCoordinates();
-    uint64_t morton_code = compute_morton(coord.x(), coord.y(), coord.z());
+    const bool is_voxel = std::is_same<DataHandlerT, VoxelBlockHandler<FieldType>>::value;
 
-    bool isVoxel = std::is_same<DataHandlerT, VoxelBlockHandler<FieldType>>::value;
+    const key_t morton_code_parent_node = handler.get_morton_code(); // parent node morton code
+    const int level_child = se::keyops::level(morton_code_parent_node) + 1;
+    // TODO find a way to pass max_level around or make it constant
+    const int max_level = 7;
+    const Eigen::Vector3i child_coord = handler.get_child_coord();
+    // compute morton code of current node / voxelblock
+    const key_t morton_code_child = se::keyops::encode(child_coord.x(),
+                                                child_coord.y(),
+                                                child_coord.z(),
+                                                level_child,
+                                                max_level);
     // invalid depth measurement
     if (depthSample <= 0) {
       return;
@@ -291,10 +300,8 @@ struct bfusion_update {
         data.st = voxel_state::kOccupied;
       } else if (prob <= THRESH_FREE) {
         data.st = voxel_state::kFree;
-        if(isVoxel){
 #pragma omp critical
-          free_blocks_->insert(morton_code);
-        }
+        free_blocks_->insert(morton_code_child);
       } else {
         // if the occupancy probability is not low or high enough => back to unknown
         data.st = voxel_state::kUnknown;
@@ -304,15 +311,13 @@ struct bfusion_update {
         bool voxelOccupied = prev_occ <= 0.5 && prob > 0.5;
         bool voxelFreed = prev_occ >= 0.5 && prob < 0.5;
         bool occupancyUpdated = handler.occupancyUpdated();
-        if (isVoxel && !occupancyUpdated && (voxelOccupied || voxelFreed)
+        if (is_voxel && !occupancyUpdated && (voxelOccupied || voxelFreed)
             && data.st != voxel_state::kFrontier) {
-          updated_blocks_->insert(morton_code);
+          updated_blocks_->insert(morton_code_child);
           handler.occupancyUpdated(true);
         }
-
       }
       handler.set(data);
-
     }
 
     if (detect_frontier_) {
@@ -321,17 +326,15 @@ struct bfusion_update {
         if (std::is_same<FieldType, OFusion>::value) {
           // conservative estimate as the occupancy probability for a free voxel is set quite low
           if (handler.isFrontier(map) && data.st == voxel_state::kFree) {
-            frontier_blocks_->insert(morton_code);
+            frontier_blocks_->insert(morton_code_child);
             data.st = voxel_state::kFrontier;
-
           }
         }
-
         handler.set(data);
       }
     }
 /*
-      bool isVoxel = std::is_same<DataHandlerT, VoxelBlockHandler<OFusion>>::value;
+      bool is_voxel = std::is_same<DataHandlerT, VoxelBlockHandler<OFusion>>::value;
       if (prev_occ >= 0.5 && data.x < 0.5 && isVoxel) {
 #pragma omp critical
         freedVoxels_.push_back(pix);

--- a/se_denseslam/src/bfusion/mapping_impl.hpp
+++ b/se_denseslam/src/bfusion/mapping_impl.hpp
@@ -261,30 +261,14 @@ struct bfusion_update {
 
     const bool is_voxel = std::is_same<DataHandlerT, VoxelBlockHandler<FieldType>>::value;
 
-    // TODO addis voxel flag
 
-
-    const key_t morton_code_parent_node = handler.get_morton_code(); // parent node morton code
-
-    const int level_child = se::keyops::level(morton_code_parent_node) ;
-    // TODO find a way to pass max_level around or make it constant
-    const int max_level = 7;
-    const Eigen::Vector3i octant_coord = handler.getNodeCoordinates();
     // compute morton code of current node / voxelblock
-    const key_t morton_code_via_handler = se::keyops::encode(octant_coord.x(),
-                                                octant_coord.y(),
-                                                octant_coord.z(),
-                                                level_child,
-                                                max_level);
+//    const key_t morton_code_via_handler = se::keyops::encode(octant_coord.x(),
+//                                                octant_coord.y(),
+//                                                octant_coord.z(),
+//                                                level_child,
+//                                                max_level);
     const key_t morton_code_child = handler.get_morton_code();
-    if(morton_code_child!=morton_code_via_handler && !is_voxel){
-      std::cout << "handler and encode not equal encode " << morton_code_child <<
-      " handler " << morton_code_via_handler <<
-      std::endl;
-      std::cout << "octant coord " << octant_coord.format(InLine) << " decode encoded " <<
-      se::keyops::decode(morton_code_child).format(InLine) << ", decode handler  " <<
-      se::keyops::decode(morton_code_via_handler).format(InLine) << std::endl;
-    }
     // invalid depth measurement
     if (depthSample <= 0) {
       return;
@@ -340,30 +324,33 @@ struct bfusion_update {
           // conservative estimate as the occupancy probability for a free voxel is set quite low
           if (handler.isFrontier(map) && data.st == voxel_state::kFree) {
 //            std::cout << "is frontier " << data.st << std::endl;
-            if(is_voxel) {
+//          check if the voxel block was allocated
+
+//            if(is_voxel) {
               frontier_blocks_->insert(morton_code_child);
               data.st = voxel_state::kFrontier;
-            } else{
-              se::Node<FieldType> * node_tmp = handler.get_node();
-              bool is_leaf = node_tmp->child(handler.get_child_idx())->isLeaf();
-              std::cout << "[se/mapping] frontier block but not added, this node is a leaf " <<
-              is_leaf << " with the coord " << handler.getNodeCoordinates() << std::endl;
-               auto p = std::find(frontier_blocks_->begin(), frontier_blocks_->end(),
-                   morton_code_child);
-               if(p!= frontier_blocks_->end()){
-                 std::cout << "node morton code was in frontier set via voxelblock update" <<
-                 std::endl;
-
-               } else{
-                 std::cout << "node morton code was not in set" << std::endl;
-               }
+//            } else{
+//              se::Node<FieldType> * node_tmp = handler.get_node();
+//              bool is_leaf = node_tmp->child(handler.get_child_idx())->isLeaf();
+//              std::cout << "[se/mapping] frontier block but not added, this node is a leaf " <<
+//              is_leaf << " with the coord " << handler.getNodeCoordinates() << std::endl;
+//               auto p = std::find(frontier_blocks_->begin(), frontier_blocks_->end(),
+//                   morton_code_child);
+//               if(p!= frontier_blocks_->end()){
+//                 std::cout << "node morton code was in frontier set via voxelblock update" <<
+//                 std::endl;
+//
+//               } else{
+//                 std::cout << "node morton code was not in set" << std::endl;
+//               }
 
             }
           }
         }
         handler.set(data);
       }
-    }
+
+
 /*
       bool is_voxel = std::is_same<DataHandlerT, VoxelBlockHandler<OFusion>>::value;
       if (prev_occ >= 0.5 && data.x < 0.5 && isVoxel) {

--- a/se_denseslam/src/bfusion/mapping_impl.hpp
+++ b/se_denseslam/src/bfusion/mapping_impl.hpp
@@ -326,6 +326,7 @@ struct bfusion_update {
         if (std::is_same<FieldType, OFusion>::value) {
           // conservative estimate as the occupancy probability for a free voxel is set quite low
           if (handler.isFrontier(map) && data.st == voxel_state::kFree) {
+//            std::cout << "is frontier " << data.st << std::endl;
             frontier_blocks_->insert(morton_code_child);
             data.st = voxel_state::kFrontier;
           }

--- a/se_denseslam/src/bfusion/mapping_impl.hpp
+++ b/se_denseslam/src/bfusion/mapping_impl.hpp
@@ -32,17 +32,17 @@
 #ifndef BFUSION_MAPPING_HPP
 #define BFUSION_MAPPING_HPP
 #include <cstdlib>
-#include <se/node.hpp>
 #include <Eigen/StdVector>
-#include <se/functors/projective_functor.hpp>
-#include <se/constant_parameters.h>
-#include <se/image/image.hpp>
-#include "bspline_lookup.cc"
 #include <atomic>
 #include <omp.h>
-
 #include <map>
-#include <se/octant_ops.hpp>
+
+#include "se/functors/projective_functor.hpp"
+#include "se/node.hpp"
+#include "se/constant_parameters.h"
+#include "se/image/image.hpp"
+#include "bspline_lookup.cc"
+#include "se/octant_ops.hpp"
 /**
  * Perform bilinear interpolation on a depth image. See
  * https://en.wikipedia.org/wiki/Bilinear_interpolation for more details.
@@ -259,10 +259,28 @@ struct bfusion_update {
     auto data = handler.get();
     float prev_occ = se::math::getProbFromLog(data.x);
 
-    Eigen::Vector3i coord = handler.getNodeCoordinates();
-    uint64_t morton_code = compute_morton(coord.x(), coord.y(), coord.z());
+    bool is_voxel = std::is_same<DataHandlerT, VoxelBlockHandler<FieldType>>::value;
 
-    bool isVoxel = std::is_same<DataHandlerT, VoxelBlockHandler<FieldType>>::value;
+    key_t morton_code_new = handler.get_mortoncode(); // parent morton code
+    int level_child = se::keyops::level(morton_code_new)+1;
+    int child_idx = handler.get_childidx();
+    key_t child_code = 0;
+
+    // compute morton code of the child / the current node / voxelblock
+
+//
+//    Node<T> **n = &root_;
+//    n = &(*n)->child(index);
+//    (*n)->code_ = myKey | level;
+//    Node *& child(const int offset ){
+    // old implementation
+    Eigen::Vector3i coord = handler.getNodeCoordinates();
+    key_t morton_code = compute_morton(coord.x(), coord.y(), coord.z());
+
+    std::cout << "se mapping get " << morton_code_new << " compute " << morton_code <<
+    std::endl;
+
+
     // invalid depth measurement
     if (depthSample <= 0) {
       return;
@@ -291,7 +309,7 @@ struct bfusion_update {
         data.st = voxel_state::kOccupied;
       } else if (prob <= THRESH_FREE) {
         data.st = voxel_state::kFree;
-        if(isVoxel){
+        if(is_voxel){
 #pragma omp critical
           free_blocks_->insert(morton_code);
         }
@@ -304,9 +322,9 @@ struct bfusion_update {
         bool voxelOccupied = prev_occ <= 0.5 && prob > 0.5;
         bool voxelFreed = prev_occ >= 0.5 && prob < 0.5;
         bool occupancyUpdated = handler.occupancyUpdated();
-        if (isVoxel && !occupancyUpdated && (voxelOccupied || voxelFreed)
+        if (is_voxel && !occupancyUpdated && (voxelOccupied || voxelFreed)
             && data.st != voxel_state::kFrontier) {
-          updated_blocks_->insert(morton_code);
+          updated_blocks_->insert(morton_code_new);
           handler.occupancyUpdated(true);
         }
 
@@ -331,7 +349,7 @@ struct bfusion_update {
       }
     }
 /*
-      bool isVoxel = std::is_same<DataHandlerT, VoxelBlockHandler<OFusion>>::value;
+      bool is_voxel = std::is_same<DataHandlerT, VoxelBlockHandler<OFusion>>::value;
       if (prev_occ >= 0.5 && data.x < 0.5 && isVoxel) {
 #pragma omp critical
         freedVoxels_.push_back(pix);

--- a/se_shared/include/se/path_planning/collision_checker.hpp
+++ b/se_shared/include/se/path_planning/collision_checker.hpp
@@ -88,8 +88,8 @@ int CollisionCheck<T>::isSphereCollisionFree(const Eigen::Vector3i center) {
             // if true keep old voxelblock pointer and fetch
             // else get new voxel block
             if ((point_v.x() / BLOCK_SIDE) == (prev_pos.x() / BLOCK_SIDE)
-                && ((point_v.y()) / BLOCK_SIDE) == (prev_pos.y() / BLOCK_SIDE)
-                && ((point_v.z()) / BLOCK_SIDE) == (prev_pos.z() / BLOCK_SIDE)) {
+                && (point_v.y() / BLOCK_SIDE) == (prev_pos.y() / BLOCK_SIDE)
+                && (point_v.z() / BLOCK_SIDE) == (prev_pos.z() / BLOCK_SIDE)) {
               if (block->data(point_v).x >= 0.f) {
 //                std::cout << " [secollision] collision at " << point_v.format(InLine) << " plog "
 //                          << block->data(point_v).x << std::endl;


### PR DESCRIPTION
Before only the morton code of voxel blocks with free and frontier voxels were added to the sets.

After the change, the morton code of unallocated voxelblocks but updated node value are also added to the set.

Node:
value[]
child_ptr[]
|                           \
|                            \
all. voxelblock:       unall. voxelblock 
child_ptr[i] :  set     child_ptr[i+1]: nullptr
value[i]: updated   value[i+1]: updated

- update insert morton code function to insert morton code of nodes
- add new getters to data handler for the private members
- add new getter to node handler to get info from nodes
- add check if the voxel / node coord are outside of the map
- update node iterator get free and frontier voxels to differentiate node and voxelblocks

NOTE: 
there are some artefacts , see attached image
![free_nodes2](https://user-images.githubusercontent.com/32288802/61940580-a3828400-af8d-11e9-9031-ce720c6ad5f9.png)

after dense allocation is added, recheck all functions and add handling of lower level nodes
