### PR TITLE
Sphere allocation

### DIFF
--- a/se_core/include/se/utils/eigen_utils.h
+++ b/se_core/include/se/utils/eigen_utils.h
@@ -19,16 +19,15 @@ typedef AlignedVector<Eigen::Vector3i> VectorVec3i;
 typedef AlignedVector<std::pair<Eigen::Vector3i, double>> VectorPair3iDouble;
 
 
-typedef std::map<int,
-                 VectorVec3i,
-                 std::less<int>,
-                 Eigen::aligned_allocator<std::pair<const int, VectorVec3i> > > mapvec3i;
 
 typedef std::map<uint64_t,
                  Eigen::Vector3i,
                  std::less<uint64_t>,
                  Eigen::aligned_allocator<std::pair<const uint64_t, Eigen::Vector3i> > > map3i;
-
+typedef std::map<uint64_t,
+                 VectorVec3i,
+                 std::less<uint64_t>,
+                 Eigen::aligned_allocator<std::pair<const uint64_t, VectorVec3i> > > mapvec3i;
 static Eigen::IOFormat
     InLine(Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", ", ", "", "", " ", ";");
 #endif //SUPEREIGHT_EIGEN_ALIGNED_ALLOCATION_H

--- a/se_core/include/se/utils/eigen_utils.h
+++ b/se_core/include/se/utils/eigen_utils.h
@@ -20,14 +20,15 @@ typedef AlignedVector<std::pair<Eigen::Vector3i, double>> VectorPair3iDouble;
 
 
 
-typedef std::map<uint64_t,
+typedef std::map<key_t ,
                  Eigen::Vector3i,
-                 std::less<uint64_t>,
-                 Eigen::aligned_allocator<std::pair<const uint64_t, Eigen::Vector3i> > > map3i;
-typedef std::map<uint64_t,
+                 std::less<key_t>,
+                 Eigen::aligned_allocator<std::pair<const key_t, Eigen::Vector3i> > > map3i;
+typedef std::map<key_t,
                  VectorVec3i,
-                 std::less<uint64_t>,
-                 Eigen::aligned_allocator<std::pair<const uint64_t, VectorVec3i> > > mapvec3i;
+                 std::less<key_t>,
+                 Eigen::aligned_allocator<std::pair<const key_t, VectorVec3i> > > mapvec3i;
+
 static Eigen::IOFormat
     InLine(Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", ", ", "", "", " ", ";");
 #endif //SUPEREIGHT_EIGEN_ALIGNED_ALLOCATION_H

--- a/se_denseslam/include/se/DenseSLAMSystem.h
+++ b/se_denseslam/include/se/DenseSLAMSystem.h
@@ -112,7 +112,7 @@ class DenseSLAMSystem {
 
   //exploration
   map3i frontier_map_;
-
+  bool first_clearance_ =false;
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -253,14 +253,9 @@ class DenseSLAMSystem {
  * \param cand_views
  * \return true if planning was performed
  */
-  bool planning(se::exploration::posevector &path, se::exploration::posevector &cand_views);
+  bool planning(se::exploration::posevector &path, se::exploration::posevector &cand_views,
+      mapvec3i *free_blocks);
 
-  /**
-   * Set all voxel in a sphere from unknown to free for planning initialization
-   * @param position [voxel coord] current position
-   * @return true if initialization was performed
-   */
-  bool initSphere(const Eigen::Vector3i position);
   /*
    * TODO Implement this.
    */

--- a/se_denseslam/include/se/DenseSLAMSystem.h
+++ b/se_denseslam/include/se/DenseSLAMSystem.h
@@ -56,7 +56,9 @@
 
 #include <se/utils/eigen_utils.h>
 #include "se/path_planning/candidate_view.hpp"
-#include <se/path_planning/exploration_utils.hpp>
+#include "se/path_planning/exploration_utils.hpp"
+#include "se/path_planning/init_new_position.hpp"
+
 /*
  * Use SE_FIELD_TYPE macro to define the DenseSLAMSystem instance.
  */
@@ -244,8 +246,21 @@ class DenseSLAMSystem {
    * \return true if raycasting was performed and false if it wasn't.
    */
   bool raycasting(const Eigen::Vector4f &k, float mu, unsigned int frame);
-
+/**
+ * Planning interface for the pipeline
+ * currently only candidate view generation and best candidate evaluation based on information gain
+ * \param path
+ * \param cand_views
+ * \return true if planning was performed
+ */
   bool planning(se::exploration::posevector &path, se::exploration::posevector &cand_views);
+
+  /**
+   * Set all voxel in a sphere from unknown to free for planning initialization
+   * @param position [voxel coord] current position
+   * @return true if initialization was performed
+   */
+  bool initSphere(const Eigen::Vector3i position);
   /*
    * TODO Implement this.
    */

--- a/se_denseslam/include/se/DenseSLAMSystem.h
+++ b/se_denseslam/include/se/DenseSLAMSystem.h
@@ -112,7 +112,7 @@ class DenseSLAMSystem {
 
   //exploration
   map3i frontier_map_;
-  bool first_clearance_ =false;
+  bool init_position_cleared_ = false;
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/se_denseslam/include/se/planner_config.h
+++ b/se_denseslam/include/se/planner_config.h
@@ -38,6 +38,12 @@ struct Planning_Configuration{
   int dphi;
   int dtheta;
 
+  bool clear_sphere_for_planning;
+
+  /**
+   * [m] set all voxel inside the sphere to voxel state free
+   */
+  float clearance_radius;
 };
 
 inline Planning_Configuration getDefaultPlanningConfig(){
@@ -48,6 +54,8 @@ inline Planning_Configuration getDefaultPlanningConfig(){
   config.dr = 0.1;
   config.dphi = 10;
   config.dtheta = 10;
+  config.clear_sphere_for_planning = true;
+  config.clearance_radius = 1.0f;
   return config;
 }
 #endif //SUPEREIGHT_PLANNER_CONFIG_H

--- a/se_denseslam/src/DenseSLAMSystem.cpp
+++ b/se_denseslam/src/DenseSLAMSystem.cpp
@@ -520,13 +520,13 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f &k,
 bool DenseSLAMSystem::planning(se::exploration::posevector &path,
                                se::exploration::posevector &cand_views,
                                mapvec3i *free_blocks) {
-  if (!first_clearance_) {
+  if (!init_position_cleared_) {
   std::cout << "[se/denseSLAM] clear sphere around robot" << std::endl;
     se::exploration::initNewPosition(pose_ * Tbc_,
                                      planning_config_,
                                      free_blocks,
                                      *volume_._map_index);
-    first_clearance_ = true;
+    init_position_cleared_ = true;
   }
   float res_v = volume_dimension_.cast<float>().x() / volume_resolution_.cast<float>().x();
 

--- a/se_denseslam/src/DenseSLAMSystem.cpp
+++ b/se_denseslam/src/DenseSLAMSystem.cpp
@@ -46,7 +46,7 @@
 #include "kfusion/mapping_impl.hpp"
 #include "bfusion/alloc_impl.hpp"
 #include "kfusion/alloc_impl.hpp"
-#include <se/boundary_extraction.hpp>
+#include "se/boundary_extraction.hpp"
 
 PerfStats Stats;
 static bool print_kernel_timing = false;
@@ -133,6 +133,7 @@ DenseSLAMSystem::DenseSLAMSystem(const Eigen::Vector2i &inputSize,
   discrete_vol_ptr_->init(volume_resolution_.x(), volume_dimension_.x());
   volume_ =
       Volume<FieldType>(volume_resolution_.x(), volume_dimension_.x(), discrete_vol_ptr_.get());
+
 }
 
 bool DenseSLAMSystem::preprocessing(const unsigned short *inputDepth,
@@ -520,6 +521,8 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f &k,
 
 bool DenseSLAMSystem::planning(se::exploration::posevector &path, se::exploration::posevector
 &cand_views) {
+
+
   std::cout << "[se/denseSLAM] planning num cand view "<< planning_config_.num_cand_views <<std::endl;
   float res_v = volume_dimension_.cast<float>().x()/volume_resolution_.cast<float>().x();
 
@@ -536,6 +539,11 @@ bool DenseSLAMSystem::planning(se::exploration::posevector &path, se::exploratio
 //  std::cout << "[se/denseSLAM] path length " << path.size() <<std::endl;
 }
 
+bool DenseSLAMSystem::initSphere(const Eigen::Vector3i position) {
+
+  // planning initialization
+  se::exploration::initNewPosition(pose_*Tbc_, planning_config_, volume_);
+}
 void DenseSLAMSystem::dump_volume(std::string) {
 
 }

--- a/se_denseslam/src/DenseSLAMSystem.cpp
+++ b/se_denseslam/src/DenseSLAMSystem.cpp
@@ -73,7 +73,7 @@ DenseSLAMSystem::DenseSLAMSystem(const Eigen::Vector2i &inputSize,
                                  const Eigen::Matrix4f &initPose,
                                  std::vector<int> &pyramid,
                                  const Configuration &config,
-                                const Planning_Configuration &planning_config )
+                                 const Planning_Configuration &planning_config)
     :
     computation_size_(inputSize),
     vertex_(computation_size_.x(), computation_size_.y()),
@@ -86,10 +86,7 @@ DenseSLAMSystem::DenseSLAMSystem(const Eigen::Vector2i &inputSize,
   this->volume_resolution_ = volumeResolution;
   this->mu_ = config.mu;
   pose_ = initPose;
-  Tbc_ << 0,0,1,0,
-         -1, 0,0,0,
-         0,-1,0,0,
-         0,0,0,1;
+  Tbc_ << 0, 0, 1, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 1;
   raycast_pose_ = initPose * Tbc_;
 
   this->iterations_.clear();
@@ -216,7 +213,7 @@ bool DenseSLAMSystem::raycasting(const Eigen::Vector4f &k, float mu, unsigned in
   bool doRaycast = false;
 
   if (frame > 2) {
-    raycast_pose_ = pose_*Tbc_; // camera to world
+    raycast_pose_ = pose_ * Tbc_; // camera to world
     float step = volume_dimension_.x() / volume_resolution_.x();
 
     //TODO maintainability
@@ -254,7 +251,7 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f &k,
       allocated = buildAllocationList(allocation_list_.data(),
                                       allocation_list_.capacity(),
                                       *volume_._map_index,
-                                      pose_* Tbc_,
+                                      pose_ * Tbc_,
                                       getCameraMatrix(k),
                                       float_depth_.data(),
                                       computation_size_,
@@ -419,7 +416,6 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f &k,
     float voxelsize = volume_._extent / volume_._size;
     int num_vox_per_pix = volume_._extent / ((se::VoxelBlock<FieldType>::side) * voxelsize);
 
-
     size_t total = num_vox_per_pix * computation_size_.x() * computation_size_.y();
     allocation_list_.reserve(total);
 
@@ -436,7 +432,7 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f &k,
       allocated = buildAllocationList(allocation_list_.data(),
                                       allocation_list_.capacity(),
                                       *volume_._map_index,
-                                      pose_*Tbc_,
+                                      pose_ * Tbc_,
                                       getCameraMatrix(k),
                                       float_depth,
                                       computation_size_,
@@ -447,7 +443,7 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f &k,
       allocated = buildOctantList(allocation_list_.data(),
                                   allocation_list_.capacity(),
                                   *volume_._map_index,
-                                  pose_* Tbc_,
+                                  pose_ * Tbc_,
                                   getCameraMatrix(k),
                                   float_depth,
                                   computation_size_,
@@ -463,7 +459,7 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f &k,
       struct sdf_update funct
           (float_depth, Eigen::Vector2i(computation_size_.x(), computation_size_.y()), mu, 100);
       se::functor::projective_map(*volume_._map_index,
-                                  Sophus::SE3f(pose_*Tbc_).inverse(),
+                                  Sophus::SE3f(pose_ * Tbc_).inverse(),
                                   getCameraMatrix(k),
                                   Eigen::Vector2i(computation_size_.x(), computation_size_.y()),
                                   funct);
@@ -477,28 +473,30 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f &k,
                                   voxelsize,
                                   updated_blocks,
                                   free_blocks,
-                                  false, 1);
+                                  false,
+                                  1);
 // Update all active nodes and voxels using the bfusion_update function
 
       se::functor::projective_map(*volume_._map_index,
-                                  Sophus::SE3f(pose_*Tbc_).inverse(),
+                                  Sophus::SE3f(pose_ * Tbc_).inverse(),
                                   getCameraMatrix(k),
                                   Eigen::Vector2i(computation_size_.x(), computation_size_.y()),
                                   funct);
       struct bfusion_update frontier_funct(float_depth,
-                                  Eigen::Vector2i(computation_size_.x(), computation_size_.y()),
-                                  mu,
-                                  timestamp,
-                                  voxelsize,
-                                  frontier_blocks,
-                                  true);
+                                           Eigen::Vector2i(computation_size_.x(),
+                                                           computation_size_.y()),
+                                           mu,
+                                           timestamp,
+                                           voxelsize,
+                                           frontier_blocks,
+                                           true);
 
       se::functor::projective_map(*volume_._map_index,
-                                  Sophus::SE3f(pose_*Tbc_).inverse(),
+                                  Sophus::SE3f(pose_ * Tbc_).inverse(),
                                   getCameraMatrix(k),
                                   Eigen::Vector2i(computation_size_.x(), computation_size_.y()),
                                   frontier_funct);
-      std::set<uint64_t > *copy_frontier_blocks = frontier_blocks;
+      std::set<uint64_t> *copy_frontier_blocks = frontier_blocks;
       bool update_frontier_map = (frame % frontier_map_update_rate) == 0;
       updateFrontierMap(volume_, frontier_map_, copy_frontier_blocks, update_frontier_map);
 
@@ -519,12 +517,18 @@ bool DenseSLAMSystem::integration(const Eigen::Vector4f &k,
   return true;
 }
 
-bool DenseSLAMSystem::planning(se::exploration::posevector &path, se::exploration::posevector
-&cand_views) {
-
-
-  std::cout << "[se/denseSLAM] planning num cand view "<< planning_config_.num_cand_views <<std::endl;
-  float res_v = volume_dimension_.cast<float>().x()/volume_resolution_.cast<float>().x();
+bool DenseSLAMSystem::planning(se::exploration::posevector &path,
+                               se::exploration::posevector &cand_views,
+                               mapvec3i *free_blocks) {
+  if (!first_clearance_) {
+  std::cout << "[se/denseSLAM] clear sphere around robot" << std::endl;
+    se::exploration::initNewPosition(pose_ * Tbc_,
+                                     planning_config_,
+                                     free_blocks,
+                                     *volume_._map_index);
+    first_clearance_ = true;
+  }
+  float res_v = volume_dimension_.cast<float>().x() / volume_resolution_.cast<float>().x();
 
   float step = volume_dimension_.x() / volume_resolution_.x();
   se::exploration::getExplorationPath(volume_,
@@ -533,17 +537,12 @@ bool DenseSLAMSystem::planning(se::exploration::posevector &path, se::exploratio
                                       step,
                                       planning_config_,
                                       config_,
-                                      pose_*Tbc_,
+                                      pose_ * Tbc_,
                                       path,
                                       cand_views);
 //  std::cout << "[se/denseSLAM] path length " << path.size() <<std::endl;
 }
 
-bool DenseSLAMSystem::initSphere(const Eigen::Vector3i position) {
-
-  // planning initialization
-  se::exploration::initNewPosition(pose_*Tbc_, planning_config_, volume_);
-}
 void DenseSLAMSystem::dump_volume(std::string) {
 
 }
@@ -603,7 +602,6 @@ void DenseSLAMSystem::dump_mesh(const std::string filename) {
   se::algorithms::marching_cube(*volume_._map_index, select, inside, mesh);
   writeVtkMesh(filename.c_str(), mesh);
 }
-
 
 bool DenseSLAMSystem::getFrontierVoxelMap(map3i &frontier_map) {
   frontier_map = frontier_map_;

--- a/se_shared/include/se/path_planning/candidate_view.hpp
+++ b/se_shared/include/se/path_planning/candidate_view.hpp
@@ -31,16 +31,16 @@
 #include "exploration_utils.hpp"
 
 template<typename T> using Volume = VolumeTemplate<T, se::Octree>;
-typedef SE_FIELD_TYPE FieldType;
+//typedef SE_FIELD_TYPE FieldType;
 namespace se {
 
 namespace exploration {
 
-static se::geometry::collision_status test_voxel2(const Volume<FieldType>::value_type &val) {
-  if (val.st == voxel_state::kUnknown) return se::geometry::collision_status::unseen;
-  if (val.st == voxel_state::kFree) return se::geometry::collision_status::empty;
-  return se::geometry::collision_status::occupied;
-};
+//static se::geometry::collision_status test_voxel2(const Volume<FieldType>::value_type &val) {
+//  if (val.st == voxel_state::kUnknown) return se::geometry::collision_status::unseen;
+//  if (val.st == voxel_state::kFree) return se::geometry::collision_status::empty;
+//  return se::geometry::collision_status::occupied;
+//};
 /**
  * Candidate View
  */
@@ -75,7 +75,6 @@ class CandidateView {
 
   std::pair<pose3D, double> getBestCandidate(const VectorPairPoseDouble &cand_list);
 
-  pose3D getCurrPose();
   const float getIGWeight_tanh(const float tanh_range,
                                const float tanh_ratio,
                                const float t,
@@ -385,7 +384,7 @@ VectorPairPoseDouble CandidateView<T>::getCandidateGain(const float step) {
   VectorPairPoseDouble cand_pose_w_gain;
 
   // add curr pose to be evaluated
-  pose3D curr_pose = getCurrPose();
+  pose3D curr_pose = getCurrPose(curr_pose_, res_);
 //  std::cout << "[se/candview] curr pose " << curr_pose.p.format(InLine) << " yaw "
 //            << toEulerAngles(curr_pose.q).yaw * 180 / M_PI << std::endl;
 //  std::cout << "[se/candview] cand view size " << cand_views_.size() << std::endl;
@@ -523,14 +522,6 @@ std::pair<pose3D,
   return std::make_pair(best_cand, max_gain);
 }
 
-// transforms current pose from matrix4f to position and orientation (quaternion)
-template<typename T>
-pose3D CandidateView<T>::getCurrPose() {
-  pose3D curr_pose;
-  curr_pose.q = se::math::rot_mat_2_quat(curr_pose_.block<3, 3>(0, 0));
-  curr_pose.p = curr_pose_.block<3, 1>(0, 3) / res_;
-  return curr_pose;
-}
 
 /**
  * calculates exploration path

--- a/se_shared/include/se/path_planning/exploration_utils.hpp
+++ b/se_shared/include/se/path_planning/exploration_utils.hpp
@@ -196,6 +196,9 @@ static inline bool saveMatrixToDepthImage(const Eigen::MatrixXd matrix,
 
   return true;
 }
+
+
+
 } //exploration
 }//namespace se
 #endif //SUPEREIGHT_EXPLORATION_UTILS_HPP

--- a/se_shared/include/se/path_planning/exploration_utils.hpp
+++ b/se_shared/include/se/path_planning/exploration_utils.hpp
@@ -197,6 +197,13 @@ static inline bool saveMatrixToDepthImage(const Eigen::MatrixXd matrix,
   return true;
 }
 
+// transforms current pose from matrix4f to position and orientation (quaternion)
+static pose3D getCurrPose(const Eigen::Matrix4f &pose, const float res){
+  pose3D curr_pose;
+  curr_pose.q = se::math::rot_mat_2_quat(pose.block<3, 3>(0, 0));
+  curr_pose.p = pose.block<3, 1>(0, 3) / res;
+  return curr_pose;
+}
 
 
 } //exploration

--- a/se_shared/include/se/path_planning/init_new_position.hpp
+++ b/se_shared/include/se/path_planning/init_new_position.hpp
@@ -103,7 +103,7 @@ static void initNewPosition(const Eigen::Matrix4f &pose,
 
   const float res = map.dim() / static_cast<float>(map.size());
   // create list with morton code (VB) and list of voxels belonging to the sphere
-  pose3D curr_pose = getCurrPose(pose, res);
+  const pose3D curr_pose = getCurrPose(pose, res);
   std::vector<se::key_t> alloc_list;
   getSphereAroundPoint(curr_pose.p.cast<int>(),
                        planning_config.clearance_radius,

--- a/se_shared/include/se/path_planning/init_new_position.hpp
+++ b/se_shared/include/se/path_planning/init_new_position.hpp
@@ -1,0 +1,97 @@
+//
+// Created by anna on 26/07/19.
+//
+
+#ifndef SUPEREIGHT_INIT_NEW_POSITION_HPP
+#define SUPEREIGHT_INIT_NEW_POSITION_HPP
+
+#include <set>
+#include <map>
+#include <cstdlib>
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <iostream>
+#include <vector>
+#include <random>
+#include <iterator>
+#include <type_traits>
+#include <cmath>
+
+#include <Eigen/StdVector>
+#include "se/geometry/octree_collision.hpp"
+#include "se/continuous/volume_template.hpp"
+#include "se/octree.hpp"
+#include "se/node_iterator.hpp"
+#include "se/constant_parameters.h"
+#include "se/ray_iterator.hpp"
+#include "se/utils/math_utils.h"
+#include "se/config.h"
+#include "se/utils/eigen_utils.h"
+#include "collision_checker.hpp"
+#include "exploration_utils.hpp"
+template<typename T> using Volume = VolumeTemplate<T, se::Octree>;
+typedef SE_FIELD_TYPE FieldType;
+namespace se {
+
+namespace exploration {
+
+/**
+ * @brief creates a std::map <morton code of voxel block, vector with voxel coord> for the voxels
+ * belonging to a sphere
+ * @param center [voxel coord]
+ * @param clearance_radius [m]
+ * @param map
+ * @param[out[ block_voxel_map [std::map]
+ */
+void getSphereAroundPoint(const Eigen::Vector3i & center, const float
+clearance_radius, const Volume<FieldType> &map, mapvec3i *block_voxel_map){
+  const int res = map._map_index->dim() / map._map_index->size();
+  const int radius_v = static_cast<int>(clearance_radius / res); // m/(m/voxel)
+  const int leaf_level = map._map_index->leaf_level();
+
+  se::Node<FieldType> *node = nullptr;
+  se::VoxelBlock<FieldType> *block = nullptr;
+  bool is_voxel_block;
+  for (int x = -radius_v; x <= radius_v; x++) {
+    for (int y = -radius_v; y <= radius_v; y++) {
+      for (int z = -radius_v; z <= radius_v; z++) {
+        Eigen::Vector3i point_offset_v(x, y, z);
+        //check if point is inside the sphere radius
+        if (point_offset_v.norm() <= radius_v) {
+          // check to wich voxelblock the voxel belongs
+          const Eigen::Vector3i point_v = point_offset_v + center;
+          const key_t morton_code = map._map_index->hash(x,y,z, leaf_level);
+          (*block_voxel_map)[morton_code].push_back(Eigen::Vector3i(x,y,z));
+
+
+        }
+
+      }//z
+    }//y
+  }//x
+
+}
+/**
+ * @brief At planning initialization, set all voxel's state  inside a sphere from
+ * unknown to free
+ * @param center
+ * @param planning_config
+ * @param volume
+ */
+void initNewPosition(const Eigen::Vector3i & center, const Planning_Configuration
+&planning_config, const Volume<FieldType> & map){
+
+  // create list with morton code (VB) and list of voxels belonging to the sphere
+
+  mapvec3i block_voxel_map;
+  getSphereAroundPoint(center, planning_config.clearance_radius, map,
+      &block_voxel_map );
+
+  // update all the voxels in side it via node iterator and set them to voxel_state kfree
+
+}
+
+
+}// namespace exploration
+}// namespace se
+#endif //SUPEREIGHT_INIT_NEW_POSITION_HPP

--- a/se_shared/include/se/path_planning/init_new_position.hpp
+++ b/se_shared/include/se/path_planning/init_new_position.hpp
@@ -71,6 +71,12 @@ static void getSphereAroundPoint(const Eigen::Vector3i &center,
 
 }
 
+/**
+ * for all voxels in the block_voxel_map, set the voxel state from unknown to free
+ * @param[in] map
+ * @param[in] block_voxel_map <voxelblock morton code, vector with voxel coord of all voxels
+ * belonging to the sphere
+ */
 template<typename FieldType>
 static void setStateToFree(Octree<FieldType> &map, mapvec3i *block_voxel_map) {
 
@@ -89,7 +95,8 @@ static void setStateToFree(Octree<FieldType> &map, mapvec3i *block_voxel_map) {
 }
 /**
  * @brief At planning initialization, set all voxel's state  inside a sphere from
- * unknown to free
+ * unknown to free,
+ * NO UPDATE to probability, Frontiers not redetected
  * @param center
  * @param planning_config
  * @param volume

--- a/se_shared/test/path_planning/candidateview_unittest.cpp
+++ b/se_shared/test/path_planning/candidateview_unittest.cpp
@@ -158,6 +158,7 @@ TEST_F(CandidateViewTest, EntropyCalculation_occ) {
 
   //THEN
 }
+// TODO fix this test!
 TEST_F(CandidateViewTest, getSphereAroundPoint ) {
   //GIVEN:
   // Allocated block: {56, 8, 248};


### PR DESCRIPTION
at first planning request, set the voxel's state inside a sphere around the robot from unknown to free. the occupancy probability will not be updated.
- planning configuration: clearance radius 
the parameter can be set in the ROS wrapper
![free_sphere1](https://user-images.githubusercontent.com/32288802/61977228-cccefe80-afe5-11e9-9f52-64b95927b2ff.png)


