### PR TITLE
Evaluation script offset

### DIFF
--- a/se_apps/src/compute_volume.cpp
+++ b/se_apps/src/compute_volume.cpp
@@ -25,6 +25,7 @@ struct arguments {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   std::string filename;
   Eigen::Vector3f map_dim;
+  Eigen::Vector3f map_offset;
 };
 
 
@@ -39,11 +40,24 @@ struct arguments parse_arguments(int argc, char** argv) {
       args.map_dim.x() = atof(argv[2]);
       args.map_dim.y() = atof(argv[3]);
       args.map_dim.z() = atof(argv[4]);
+	  args.map_offset = Eigen::Vector3f::Constant(0.f);
+      break;
+
+    // Map filename, dimensions and offset supplied.
+    case 8:
+      args.filename = std::string(argv[1]);
+      args.map_dim.x()    = atof(argv[2]);
+      args.map_dim.y()    = atof(argv[3]);
+      args.map_dim.z()    = atof(argv[4]);
+      args.map_offset.x() = atof(argv[5]);
+      args.map_offset.y() = atof(argv[6]);
+      args.map_offset.z() = atof(argv[7]);
       break;
 
     // Show usage message.
     default:
-      std::cout << "Usage: " << argv[0] << " FILENAME DIM_X DIM_Y DIM_Z\n";
+      std::cout << "Usage: " << argv[0]
+          << " FILENAME DIM_X DIM_Y DIM_Z [OFFSET_X OFFSET_Y OFFSET_Z]\n";
       exit(EXIT_FAILURE);
   }
 
@@ -101,7 +115,7 @@ int main(int argc, char** argv) {
   float  occupied_voxel_volume;
   float  free_node_volume;
   float  occupied_node_volume;
-  compute_bounded_volume(*octree_, args.map_dim,
+  compute_bounded_volume(*octree_, args.map_dim, args.map_offset,
       free_voxel_volume, occupied_voxel_volume,
       free_node_volume, occupied_node_volume);
 

--- a/se_denseslam/include/se/post_processing.hpp
+++ b/se_denseslam/include/se/post_processing.hpp
@@ -260,6 +260,7 @@ void crop_octree(se::Octree<T>& octree, const Eigen::Vector3f& dim) {
 template<typename T>
 void compute_bounded_volume(se::Octree<T>&         octree,
                             const Eigen::Vector3f& dim,
+                            const Eigen::Vector3f& offset,
                             float&                 free_voxel_volume,
                             float&                 occupied_voxel_volume,
                             float&                 free_node_volume,
@@ -268,10 +269,10 @@ void compute_bounded_volume(se::Octree<T>&         octree,
   // centered on [0 0 0]^T. Offset it so that it's centered inside the octree.
   // Increase the z offset so that the map's floor is halfway on the octree's z
   // axis.
-  const Eigen::Vector3f map_offset (octree.dim() / 2.f, octree.dim() / 2.f,
+  const Eigen::Vector3f center_offset (octree.dim() / 2.f, octree.dim() / 2.f,
       octree.dim() / 2.f + dim.z() / 2.f);
-  const Eigen::Vector3f min_pos_m = -dim / 2.f + map_offset;
-  const Eigen::Vector3f max_pos_m =  dim / 2.f + map_offset;
+  const Eigen::Vector3f min_pos_m = -dim / 2.f + center_offset + offset;
+  const Eigen::Vector3f max_pos_m =  dim / 2.f + center_offset + offset;
 
   //std::cout << dim.format(line_fmt) << " m\n";
   //std::cout << min_pos_m.format(line_fmt) << " m\n";

--- a/se_denseslam/test/post_processing/post_processing_unittest.cpp
+++ b/se_denseslam/test/post_processing/post_processing_unittest.cpp
@@ -256,7 +256,7 @@ TEST_F(TestOctree, ComputeVolumeExact) {
   float  occupied_voxel_volume;
   float  free_node_volume;
   float  occupied_node_volume;
-  compute_bounded_volume(*octree_, dim,
+  compute_bounded_volume(*octree_, dim, Eigen::Vector3f::Constant(0.f),
       free_voxel_volume, occupied_voxel_volume,
       free_node_volume, occupied_node_volume);
 
@@ -400,7 +400,7 @@ TEST_F(TestOctree2, ComputeVolumeExact) {
   float  occupied_voxel_volume;
   float  free_node_volume;
   float  occupied_node_volume;
-  compute_bounded_volume(*octree_, dim,
+  compute_bounded_volume(*octree_, dim, Eigen::Vector3f::Constant(0.f),
       free_voxel_volume, occupied_voxel_volume,
       free_node_volume, occupied_node_volume);
 
@@ -432,7 +432,7 @@ TEST_F(TestOctree2, ComputeVolumeNonExact) {
   float  occupied_voxel_volume;
   float  free_node_volume;
   float  occupied_node_volume;
-  compute_bounded_volume(*octree_, dim,
+  compute_bounded_volume(*octree_, dim, Eigen::Vector3f::Constant(0.f),
       free_voxel_volume, occupied_voxel_volume,
       free_node_volume, occupied_node_volume);
 

--- a/se_tools/scripts/se_visualize_exploration.m
+++ b/se_tools/scripts/se_visualize_exploration.m
@@ -203,7 +203,7 @@ plot(t, voxel_volume, 'ro-', 'LineWidth', lw);
 xlabel('Time (s)');
 ylabel('Explored volume (m^3)');
 legend('Total volume', 'Node volume', 'Voxel volume', 'Location', 'southeast');
-axis([0 15*60], [0 world_volume]);
+axis([0 t(end) 0 world_volume]);
 
 if export_plot
   directory = fileparts(filenames{1});

--- a/se_tools/scripts/se_visualize_exploration.m
+++ b/se_tools/scripts/se_visualize_exploration.m
@@ -71,7 +71,7 @@ end
 function [filenames, world] = parse_arguments()
 	% Get the command line arguments.
 	args = argv();
-	if isempty(args)
+	if isempty(args) || length(args) < 3
       name = program_invocation_name();
 	  fprintf('Usage: %s [-w WORLD] FILE1 [FILE2 ...]\n', name);
 	  fprintf('  Use bash globbing with * to select all files of interest, e.g.\n');
@@ -116,7 +116,8 @@ end
 % Find the world index.
 world_ind = find(ismember(world_names, world));
 if isempty(world_ind)
-	world_ind = 1;
+	fprintf('Invalid world name: %s\n', world);
+	return;
 end
 % Get the world parameters.
 dim_x = world_dims_x(world_ind);
@@ -143,12 +144,15 @@ for i = 1:length(filenames);
   % This is a map, process.
   if strfind(filename, '.bin')
     % Evaluate the file.
-    [status, output] = system([voxelcounter_program ' ' filename ' ' ...
+	command = [voxelcounter_program ' ' filename ' ' ...
         num2str(dim_x) ' ' num2str(dim_y) ' ' num2str(dim_z) ' ' ...
-        num2str(off_x) ' ' num2str(off_y) ' ' num2str(off_z)]);
+        num2str(off_x) ' ' num2str(off_y) ' ' num2str(off_z)];
+    [status, output] = system(command);
 	if status ~= 0
-		fprintf('Error from %s\n', voxelcounter_program);
+		fprintf('Error from %s\n', command);
+		fprintf('Output -----\n');
 		fprintf('%s', output);
+		fprintf('------------\n');
 		continue;
 	end
 

--- a/se_tools/scripts/se_visualize_exploration.m
+++ b/se_tools/scripts/se_visualize_exploration.m
@@ -82,6 +82,25 @@ end
 
 
 
+function [filenames, world] = parse_arguments()
+	% Get the command line arguments.
+	args = argv();
+	if isempty(args)
+	  fprintf('Usage: %s FILE1 [FILE2 ...]\n', program_invocation_name());
+	  fprintf('  Use bash globbing with * to select all files of interest, e.g.\n');
+	  fprintf('  %s map_1/map_2019-08-22_184424_*\n', program_invocation_name());
+	  return;
+	end
+
+	% Get the world name.
+	world = 'apartment';
+
+	% Sort the filenames.
+	filenames = sort(args);
+end
+
+
+
 % Main %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Get the path to the program used to evaluate maps.
 [script_dir, ~, ~] = fileparts(program_invocation_name());
@@ -89,23 +108,14 @@ voxelcounter_program = [script_dir ...
     '/../../build/Release/se_apps/se-denseslam-ofusion-compute-volume'];
 addpath(genpath([script_dir '/octave_functions']));
 
-% Get the command line arguments.
-args = argv();
-if isempty(args)
-  fprintf('Usage: %s FILE1 [FILE2 ...]\n', program_invocation_name());
-  fprintf('  Use bash globbing with * to select all files of interest, e.g.\n');
-  fprintf('  %s map_1/map_2019-08-22_184424_*\n', program_invocation_name());
-  return;
-end
-
 t = [];
 total_volume = [];
 voxel_volume = [];
 node_volume  = [];
 poses = {};
 
-% Sort the filenames.
-filenames = sort(args);
+% Parse command line arguments.
+[filenames, world] = parse_arguments();
 
 % Iterate over each file.
 for i = 1:length(filenames);
@@ -186,15 +196,15 @@ legend('Total volume', 'Node volume', 'Voxel volume', 'Location', 'southeast');
 axis([0 10*60], [0 600]);
 
 if export_plot
-  directory = fileparts(args{1});
-  timestamp = get_pattern(timestamp_pattern, args{1});
+  directory = fileparts(filenames{1});
+  timestamp = get_pattern(timestamp_pattern, filenames{1});
   image_name = [directory '/' 'data_plot_' timestamp '.png'];
   print(image_name);
 end
 
 if export_data
-  directory = fileparts(args{1});
-  timestamp = get_pattern(timestamp_pattern, args{1});
+  directory = fileparts(filenames{1});
+  timestamp = get_pattern(timestamp_pattern, filenames{1});
   data_file_name = [directory '/' 'data_' timestamp '.csv'];
     % The columns of the .csv file are:
     % timestamp, volume of explored voxels, volume of explored nodes, total

--- a/se_tools/scripts/se_visualize_exploration.m
+++ b/se_tools/scripts/se_visualize_exploration.m
@@ -25,9 +25,28 @@ clear variables
 
 
 % Settings %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Apartment
 dim_x = 10;
 dim_y = 20;
 dim_z = 3;
+off_x = 0;
+off_y = 0;
+off_z = 0;
+% Maze
+%dim_x = 20;
+%dim_y = 20;
+%dim_z = 2.5;
+%off_x = 0.018794;
+%off_y = -5.61;
+%off_z = 0;
+% Powerplant
+%dim_x = 33;
+%dim_y = 31;
+%dim_z = 26;
+%off_x = 7.5;
+%off_y = -8.5;
+%off_z = 0;
+
 plot_path   = false;
 interactive = false;
 export_plot = true;
@@ -105,7 +124,8 @@ for i = 1:length(filenames);
   if strfind(filename, '.bin')
     % Evaluate the file.
     [status, output] = system([voxelcounter_program ' ' filename ' ' ...
-        num2str(dim_x) ' ' num2str(dim_y) ' ' num2str(dim_z)]);
+        num2str(dim_x) ' ' num2str(dim_y) ' ' num2str(dim_z) ' ' ...
+        num2str(off_x) ' ' num2str(off_y) ' ' num2str(off_z)]);
 	if status ~= 0
 		fprintf('Error from %s\n', voxelcounter_program);
 		fprintf('%s', output);


### PR DESCRIPTION
* `se-denseslam-ofusion-compute-volume` now accepts 3 extra optional parameters with the x, y and z coordinates of the world center.
* `se_tools/scripts/se_visualize_exploration.m` now accepts and optional argument `-w WORLD` where WORLD is the name of the world used in the simulation. This affects the volume cropping. E.g. for powerplant call like this: `se_tools/scripts/se_visualize_exploration.m -w powerplant ~/benchmark_evaluation/map_*`